### PR TITLE
Link: Cast roles to characters

### DIFF
--- a/server/lib/cypher-templates/person.js
+++ b/server/lib/cypher-templates/person.js
@@ -1,12 +1,13 @@
 const getShowQuery = () => `
 	MATCH (person:Person { uuid: $uuid })
 	OPTIONAL MATCH (person)-[:PERFORMS_IN]->(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
-	WITH person, production, theatre
 	OPTIONAL MATCH (person)-[roleRel:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
-	WITH person, production, theatre, roleRel, role
+	OPTIONAL MATCH (role)<-[:PERFORMS_AS]-(person)-[:PERFORMS_IN]->(production)-[:PRODUCTION_OF]->
+		(playtext)-[:INCLUDES_CHARACTER]->(character) WHERE role.name = character.name
+	WITH person, production, theatre, roleRel, role, character
 	ORDER BY roleRel.position
-	WITH person, production, theatre,
-		CASE WHEN role IS NULL THEN [{ name: 'Performer' }] ELSE COLLECT({ name: role.name }) END AS roles
+	WITH person, production, theatre, CASE WHEN role IS NULL THEN [{ name: 'Performer' }] ELSE
+		COLLECT({ model: 'character', uuid: character.uuid, name: role.name }) END AS roles
 	WITH person, CASE WHEN production IS NULL THEN [] ELSE
 		COLLECT({
 			model: 'production',

--- a/server/lib/handlebars-helpers/index.js
+++ b/server/lib/handlebars-helpers/index.js
@@ -1,5 +1,6 @@
 import concat from './concat';
 import dateformatNow from './date-format-now';
+import instanceLink from '../instance-link';
 import instanceRoute from '../instance-route';
 import join from './join';
 import json from './json';
@@ -9,6 +10,7 @@ import upperCase from './upper-case';
 export {
 	concat,
 	dateformatNow,
+	instanceLink,
 	instanceRoute,
 	join,
 	json,

--- a/server/lib/handlebars-helpers/join.js
+++ b/server/lib/handlebars-helpers/join.js
@@ -1,1 +1,10 @@
-export default (array, property) => array.map(item => item[property]).join(' / ');
+import instanceLink from '../instance-link';
+
+export default instances => {
+
+	return instances.map(instance =>
+			(instance.model && instance.uuid) ? instanceLink(instance) : instance.name
+		)
+		.join(' / ');
+
+};

--- a/server/lib/instance-link.js
+++ b/server/lib/instance-link.js
@@ -1,0 +1,3 @@
+import instanceRoute from './instance-route';
+
+export default instance => `<a href="${instanceRoute(instance)}">${instance.name}</a>`;

--- a/spec/server/lib/cypher-templates/person.spec.js
+++ b/spec/server/lib/cypher-templates/person.spec.js
@@ -14,12 +14,13 @@ describe('Cypher Templates Person module', () => {
 			expect(removeWhitespace(result)).to.eq(removeWhitespace(`
 				MATCH (person:Person { uuid: $uuid })
 				OPTIONAL MATCH (person)-[:PERFORMS_IN]->(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
-				WITH person, production, theatre
 				OPTIONAL MATCH (person)-[roleRel:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
-				WITH person, production, theatre, roleRel, role
+				OPTIONAL MATCH (role)<-[:PERFORMS_AS]-(person)-[:PERFORMS_IN]->(production)-[:PRODUCTION_OF]->
+					(playtext)-[:INCLUDES_CHARACTER]->(character) WHERE role.name = character.name
+				WITH person, production, theatre, roleRel, role, character
 				ORDER BY roleRel.position
-				WITH person, production, theatre,
-					CASE WHEN role IS NULL THEN [{ name: 'Performer' }] ELSE COLLECT({ name: role.name }) END AS roles
+				WITH person, production, theatre, CASE WHEN role IS NULL THEN [{ name: 'Performer' }] ELSE
+					COLLECT({ model: 'character', uuid: character.uuid, name: role.name }) END AS roles
 				WITH person, CASE WHEN production IS NULL THEN [] ELSE
 					COLLECT({
 						model: 'production',

--- a/spec/server/lib/handlebars-helpers/join.spec.js
+++ b/spec/server/lib/handlebars-helpers/join.spec.js
@@ -1,13 +1,43 @@
 const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
 
-const subject = require('../../../../dist/lib/handlebars-helpers/join');
+const sandbox = sinon.sandbox.create();
+
+let stubs;
+let subject;
+
+beforeEach(() => {
+
+	stubs = {
+		instanceLink: sandbox.stub().returns('instanceLink response')
+	};
+
+	subject = proxyquire('../../../../dist/lib/handlebars-helpers/join', {
+			'../instance-link': stubs.instanceLink
+		});
+
+});
+
+afterEach(() => {
+
+	sandbox.restore();
+
+});
 
 describe('Join handlebars helper', () => {
 
-	it('will return specified property value from each object in array as single concatenated string', () => {
+	it('will return instanceLink response when model and uuid present otherwise will return instance name value', () => {
 
-		const objectArray = [{ name: 'Hamlet' }, { name: 'Claudius' }, { name: 'Gertrude' }];
-		expect(subject(objectArray, 'name')).to.eq('Hamlet / Claudius / Gertrude');
+		const instancesArray = [
+			{ name: 'Hamlet' },
+			{ model: 'character', name: 'Claudius' },
+			{ name: 'Gertrude', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+			{ model: 'character', name: 'Ophelia', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
+		];
+		expect(subject(instancesArray)).to.eq('Hamlet / Claudius / Gertrude / instanceLink response');
+		expect(stubs.instanceLink.calledOnce).to.be.true;
+		expect(stubs.instanceLink.calledWithExactly(instancesArray[3])).to.be.true;
 
 	});
 

--- a/spec/server/lib/instance-link.spec.js
+++ b/spec/server/lib/instance-link.spec.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const sandbox = sinon.sandbox.create();
+
+let stubs;
+let subject;
+
+beforeEach(() => {
+
+	stubs = {
+		instanceRoute: sandbox.stub().returns('instanceRoute response')
+	};
+
+	subject = proxyquire('../../../dist/lib/instance-link', {
+			'./instance-route': stubs.instanceRoute
+		});
+
+});
+
+afterEach(() => {
+
+	sandbox.restore();
+
+});
+
+describe('Instance Link module', () => {
+
+	it('will return URL (pluralised model name and uuid) for instance', () => {
+
+		const productionInstance = { name: 'Hamlet' };
+		expect(subject(productionInstance)).to.eq('<a href="instanceRoute response">Hamlet</a>');
+		expect(stubs.instanceRoute.calledOnce).to.be.true;
+		expect(stubs.instanceRoute.calledWithExactly(productionInstance)).to.be.true;
+
+	});
+
+});

--- a/views/models/productions/show.html
+++ b/views/models/productions/show.html
@@ -26,7 +26,7 @@
 						<li>
 							{{> instance-link}} …
 							<span class="role-text">
-								{{join roles 'name'}}
+								{{{join roles}}}
 							</span>
 						</li>
 					{{/each}}

--- a/views/partials/instance-link.html
+++ b/views/partials/instance-link.html
@@ -1,3 +1,1 @@
-<a href="{{instanceRoute this}}">
-	{{~this.name~}}
-</a>
+{{{instanceLink this}}}

--- a/views/partials/show.html
+++ b/views/partials/show.html
@@ -10,7 +10,7 @@
 							{{#if roles}}
 								…
 								<span class="role-text">
-									{{join roles 'name'}}
+									{{{join roles}}}
 								</span>
 							{{/if}}
 						</li>


### PR DESCRIPTION
Will create link between cast role to playtext character (on both Production cast list and Person production credits) when there is an exact role name-character name match (characters being sourced from playtext that production uses).

![link-cast-roles-to-characters](https://user-images.githubusercontent.com/10484515/27768331-723960c6-5f08-11e7-857a-00b5160866c4.png)
