### PR TITLE
Add: Role characterName property to connect to Character

### DIFF
--- a/client/scripts/add-remove-field.js
+++ b/client/scripts/add-remove-field.js
@@ -35,7 +35,8 @@ const addField = event => {
 			const newFieldInput = newField.getElementsByTagName('input')[0];
 			newFieldInput.setAttribute('name', newFieldInputName);
 			newFieldInput.value = '';
-			newFieldInput.addEventListener('input', addField, false);
+			const requiresInputListener = newFieldInput.classList.contains('field__input--last-in-array')
+			if (requiresInputListener) newFieldInput.addEventListener('input', addField, false);
 
 			newField.getElementsByTagName('label')[0].setAttribute('for', newFieldInputName);
 

--- a/server/lib/cypher-templates/character.js
+++ b/server/lib/cypher-templates/character.js
@@ -2,33 +2,40 @@ const getShowQuery = () => `
 	MATCH (character:Character { uuid: $uuid })
 	OPTIONAL MATCH (character)<-[playtextRel:INCLUDES_CHARACTER]-(playtext:Playtext)
 	OPTIONAL MATCH (character)<-[playtextRel]-(playtext)<-[prodRel:PRODUCTION_OF]-(production:Production)<-
-		[castRel:PERFORMS_IN]-(person:Person)-[:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
-		WHERE character.name = role.name
+		[castRel:PERFORMS_IN]-(person:Person)-[roleRel:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
+		WHERE character.name = role.name OR character.name = role.characterName
 	OPTIONAL MATCH (person)-[otherRoleRel:PERFORMS_AS { prodUuid: production.uuid }]->(otherRole:Role)
 		WHERE otherRole.name <> character.name
-	OPTIONAL MATCH (otherRole)<-[otherRoleRel]-(person)-[castRel]->(production)-[prodRel]->(playtext)-[:INCLUDES_CHARACTER]->(otherCharacter:Character) WHERE otherRole.name = otherCharacter.name
+		AND (NOT EXISTS(otherRole.characterName) OR otherRole.characterName <> character.name)
+	OPTIONAL MATCH (otherRole)<-[otherRoleRel]-(person)-[castRel]->(production)-[prodRel]->
+		(playtext)-[:INCLUDES_CHARACTER]->(otherCharacter:Character)
+		WHERE otherRole.name = otherCharacter.name OR otherRole.characterName = otherCharacter.name
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
-	WITH character, production, theatre, castRel, person, role, otherRole, otherRoleRel, otherCharacter, CASE WHEN playtext IS NULL THEN [] ELSE
-		COLLECT({
-			model: 'playtext',
-			uuid: playtext.uuid,
-			name: playtext.name
-		}) END AS playtexts
+	WITH character, production, theatre, castRel, person, role, otherRole, otherRoleRel, otherCharacter,
+		CASE WHEN playtext IS NULL THEN [] ELSE
+			COLLECT({
+				model: 'playtext',
+				uuid: playtext.uuid,
+				name: playtext.name
+			}) END AS playtexts
 	ORDER BY otherRoleRel.position
-	WITH character, playtexts, production, theatre, castRel, person, role, CASE WHEN otherRole IS NULL THEN [] ELSE
-		COLLECT({
-			model: 'character',
-			uuid: otherCharacter.uuid,
-			name: otherRole.name
-		}) END AS otherRoles
+	WITH character, playtexts, production, theatre, castRel, person, role,
+		CASE WHEN otherRole IS NULL THEN [] ELSE
+			COLLECT({
+				model: 'character',
+				uuid: otherCharacter.uuid,
+				name: otherRole.name
+			}) END AS otherRoles
 	ORDER BY castRel.position
-	WITH character, playtexts, production, theatre, COLLECT({
-			model: 'person',
-			uuid: person.uuid,
-			name: person.name,
-			role: { name: role.name },
-			otherRoles: otherRoles
-		}) AS performers
+	WITH character, playtexts, production, theatre, role,
+		CASE WHEN person IS NULL THEN [] ELSE
+			COLLECT({
+				model: 'person',
+				uuid: person.uuid,
+				name: person.name,
+				role: { name: role.name },
+				otherRoles: otherRoles
+			}) END AS performers
 	RETURN {
 		model: 'character',
 		uuid: character.uuid,
@@ -41,7 +48,8 @@ const getShowQuery = () => `
 				name: production.name,
 				theatre: { model: 'theatre', uuid: theatre.uuid, name: theatre.name },
 				performers: performers
-			}) END
+			}) END,
+		variantNames: FILTER(roleName IN COLLECT(DISTINCT(role.name)) WHERE roleName <> character.name)
 	} AS character
 `;
 

--- a/server/lib/cypher-templates/person.js
+++ b/server/lib/cypher-templates/person.js
@@ -3,7 +3,8 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (person)-[castRel:PERFORMS_IN]->(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
 	OPTIONAL MATCH (person)-[roleRel:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
 	OPTIONAL MATCH (role)<-[roleRel]-(person)-[castRel]->(production)-[:PRODUCTION_OF]->
-		(:Playtext)-[:INCLUDES_CHARACTER]->(character:Character) WHERE role.name = character.name
+		(:Playtext)-[:INCLUDES_CHARACTER]->(character:Character)
+		WHERE role.name = character.name OR role.characterName = character.name
 	WITH person, production, theatre, roleRel, role, character
 	ORDER BY roleRel.position
 	WITH person, production, theatre, CASE WHEN role IS NULL THEN [{ name: 'Performer' }] ELSE

--- a/server/lib/handlebars-helpers/join.js
+++ b/server/lib/handlebars-helpers/join.js
@@ -3,7 +3,7 @@ import instanceLink from '../instance-link';
 export default instances => {
 
 	return instances.map(instance =>
-			(instance.model && instance.uuid) ? instanceLink(instance) : instance.name
+			(instance.model && instance.uuid) ? instanceLink(instance) : (instance.name || instance)
 		)
 		.join(' / ');
 

--- a/server/lib/validate-string.js
+++ b/server/lib/validate-string.js
@@ -4,6 +4,8 @@ export default (stringValue, opts = {}) => {
 
 	const stringErrors = [];
 
+	if (stringValue === null) return stringErrors;
+
 	if (opts.required && (stringValue.length < constants.STRING_MIN_LENGTH)) {
 
 		stringErrors.push('Name is too short');

--- a/server/models/role.js
+++ b/server/models/role.js
@@ -10,6 +10,7 @@ export default class Role {
 		});
 
 		this.name = props.name;
+		this.characterName = (props.characterName && props.characterName.length) ? props.characterName : null;
 		this.hasError = false;
 		this.errors = {};
 
@@ -22,6 +23,10 @@ export default class Role {
 		const nameErrors = validateString(this.name, opts);
 
 		if (nameErrors.length) this.errors.name = nameErrors;
+
+		const characterNameErrors = validateString(this.characterName, opts);
+
+		if (characterNameErrors.length) this.errors.characterName = characterNameErrors;
 
 	};
 

--- a/spec/server/lib/cypher-templates/production.spec.js
+++ b/spec/server/lib/cypher-templates/production.spec.js
@@ -30,7 +30,8 @@ describe('Cypher Templates Production module', () => {
 					ON CREATE SET person.uuid = castMember.uuid
 					CREATE (production)<-[:PERFORMS_IN { position: castMember.position }]-(person)
 					FOREACH (role in castMember.roles |
-						CREATE (person)-[:PERFORMS_AS { position: role.position, prodUuid: $uuid }]->(:Role { name: role.name })
+						CREATE (person)-[:PERFORMS_AS { position: role.position, prodUuid: $uuid }]->
+							(:Role { name: role.name, characterName: role.characterName })
 					)
 				)
 				RETURN {
@@ -72,7 +73,8 @@ describe('Cypher Templates Production module', () => {
 					ON CREATE SET person.uuid = castMember.uuid
 					CREATE (production)<-[:PERFORMS_IN { position: castMember.position }]-(person)
 					FOREACH (role in castMember.roles |
-						CREATE (person)-[:PERFORMS_AS { position: role.position, prodUuid: $uuid }]->(:Role { name: role.name })
+						CREATE (person)-[:PERFORMS_AS { position: role.position, prodUuid: $uuid }]->
+							(:Role { name: role.name, characterName: role.characterName })
 					)
 				)
 				RETURN {

--- a/spec/server/lib/handlebars-helpers/join.spec.js
+++ b/spec/server/lib/handlebars-helpers/join.spec.js
@@ -27,17 +27,18 @@ afterEach(() => {
 
 describe('Join handlebars helper', () => {
 
-	it('will return instanceLink response when model and uuid present otherwise will return instance name value', () => {
+	it('will return instanceLink response when model and uuid present otherwise instance name value or instance itself if name value absent', () => {
 
 		const instancesArray = [
-			{ name: 'Hamlet' },
-			{ model: 'character', name: 'Claudius' },
-			{ name: 'Gertrude', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
-			{ model: 'character', name: 'Ophelia', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
+			{ model: 'character', name: 'Hamlet', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+			{ name: 'Claudius', uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+			{ model: 'character', name: 'Gertrude' },
+			{ name: 'Ophelia' },
+			'Polonius'
 		];
-		expect(subject(instancesArray)).to.eq('Hamlet / Claudius / Gertrude / instanceLink response');
+		expect(subject(instancesArray)).to.eq('instanceLink response / Claudius / Gertrude / Ophelia / Polonius');
 		expect(stubs.instanceLink.calledOnce).to.be.true;
-		expect(stubs.instanceLink.calledWithExactly(instancesArray[3])).to.be.true;
+		expect(stubs.instanceLink.calledWithExactly(instancesArray[0])).to.be.true;
 
 	});
 

--- a/spec/server/lib/validate-string.spec.js
+++ b/spec/server/lib/validate-string.spec.js
@@ -42,4 +42,14 @@ describe('Validate String module', () => {
 
 	});
 
+	context('null data', () => {
+
+		it('will return empty stringErrors array', () => {
+
+			expect(subject(null)).to.deep.eq([]);
+
+		});
+
+	});
+
 });

--- a/spec/server/models/role.spec.js
+++ b/spec/server/models/role.spec.js
@@ -42,14 +42,16 @@ describe('Role model', () => {
 
 	describe('validate method', () => {
 
-		it('will trim strings before validating name', () => {
+		it('will trim strings before validating name and characterName', () => {
 
 			instance.validate();
-			expect(stubs.trimStrings.calledBefore(stubs.validateString)).to.be.true;
+			sinon.assert.callOrder(
+				stubs.trimStrings.withArgs(instance),
+				stubs.validateString.withArgs(instance.name, {}),
+				stubs.validateString.withArgs(instance.characterName, {})
+			);
 			expect(stubs.trimStrings.calledOnce).to.be.true;
-			expect(stubs.trimStrings.calledWithExactly(instance)).to.be.true;
-			expect(stubs.validateString.calledOnce).to.be.true;
-			expect(stubs.validateString.calledWithExactly(instance.name, {})).to.be.true;
+			expect(stubs.validateString.calledTwice).to.be.true;
 
 		});
 

--- a/views/models/characters/show.html
+++ b/views/models/characters/show.html
@@ -3,6 +3,13 @@
 	contentLabelText='Playtexts'
 }}
 
+<div class="content-wrapper">
+	{{> content-label text='Variant names'}}
+	<div class="content">
+		<span class="role-text">{{join instance.variantNames}}</span>
+	</div>
+</div>
+
 {{> show-instances
 	instances=instance.productions
 	contentLabelText='Productions'

--- a/views/models/productions/form.html
+++ b/views/models/productions/form.html
@@ -43,6 +43,13 @@
 							removeFieldButton=true
 							nested=true
 						}}
+						{{> input-text
+							labelText='Character'
+							inputName=(concat 'cast[' @../index '][roles][' @index '][characterName]')
+							value=characterName
+							errors=errors.characterName
+							nested=true
+						}}
 					{{/each}}
 					{{> input-text
 						labelText='Role'
@@ -50,6 +57,13 @@
 						value=''
 						errors=null
 						lastInArray=true
+						nested=true
+					}}
+					{{> input-text
+						labelText='Character'
+						inputName=(concat 'cast[' @index '][roles][' roles.length '][characterName]')
+						value=''
+						errors=null
 						nested=true
 					}}
 				{{else}}
@@ -78,6 +92,13 @@
 				lastInArray=true
 				nested=true
 			}}
+			{{> input-text
+				labelText='Character'
+				inputName=(concat 'cast[' cast.length '][roles][0][characterName]')
+				value=''
+				errors=null
+				nested=true
+			}}
 		{{else}}
 			{{> input-text
 				labelText='Cast member'
@@ -92,6 +113,13 @@
 				value=''
 				errors=null
 				lastInArray=true
+				nested=true
+			}}
+			{{> input-text
+				labelText='Character'
+				inputName=(concat 'cast[0][roles][0][characterName]')
+				value=''
+				errors=null
 				nested=true
 			}}
 		{{/if}}


### PR DESCRIPTION
Adds `characterName` property to Role instances that allow them to be connected to Characters when a different name is used than that given in the playtext.

![role-charactername-prop](https://user-images.githubusercontent.com/10484515/28247872-af8fbf7c-6a31-11e7-8574-dcb9610f6c25.png)