### PR TITLE
Use Preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
     "express-session": "^1.14.1",
     "morgan": "^1.5.1",
     "node-fetch": "^2.6.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "preact": "^10.4.1",
+    "preact-render-to-string": "^5.1.6",
     "regenerator-runtime": "^0.13.2",
     "serve-favicon": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
+    "@babel/plugin-transform-react-jsx": "^7.9.4",
     "@babel/preset-env": "^7.4.5",
-    "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.9.0",
     "babel-loader": "^8.0.6",
     "chai": "^4.2.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,49 +1,45 @@
-import React, { Component } from 'react';
+import { h } from 'preact';
 
 import { Footer, Head, Header, InstanceLabel, Navigation, PageTitle } from '.';
 
-export default class App extends Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, model, children } = props;
 
-		const { documentTitle, pageTitle, model, children } = this.props;
+	return (
+		<html>
 
-		return (
-			<html>
+			<Head documentTitle={documentTitle} />
 
-				<Head documentTitle={documentTitle} />
+			<body>
 
-				<body>
+				<div className="page-container">
 
-					<div className="page-container">
+					<Header />
 
-						<Header />
+					<Navigation />
 
-						<Navigation />
+					<main className="main-content">
 
-						<main className="main-content">
+						{
+							model && (
+								<InstanceLabel text={model} />
+							)
+						}
 
-							{
-								model && (
-									<InstanceLabel text={model} />
-								)
-							}
+						<PageTitle text={pageTitle} />
 
-							<PageTitle text={pageTitle} />
+						{ children }
 
-							{ children }
+					</main>
 
-						</main>
+					<Footer />
 
-						<Footer />
+				</div>
 
-					</div>
+			</body>
 
-				</body>
+		</html>
+	);
 
-			</html>
-		);
-
-	}
-
-}
+};

--- a/src/components/AppendedPerformerOtherRoles.jsx
+++ b/src/components/AppendedPerformerOtherRoles.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment, h } from 'preact';
 
 import { JoinedRoles } from '.';
 
@@ -7,13 +7,13 @@ export default function (props) {
 	const { otherRoles } = props;
 
 	return (
-		<React.Fragment>
+		<Fragment>
 
 			<span>; also performed:&nbsp;</span>
 
 			<JoinedRoles instances={otherRoles} />
 
-		</React.Fragment>
+		</Fragment>
 	);
 
 };

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment, h } from 'preact';
 
 import { InstanceLink, AppendedPerformerOtherRoles } from '.';
 
@@ -7,16 +7,16 @@ export default function (props) {
 	const { performers } = props;
 
 	return (
-		<React.Fragment>
+		<Fragment>
 
 			<span>&nbsp;- performed by:&nbsp;</span>
 
 			{
 				performers
 					.map((performer, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
-							<React.Fragment>
+							<Fragment>
 
 								<InstanceLink instance={performer} />
 
@@ -24,7 +24,7 @@ export default function (props) {
 
 								<span className="role-text">{performer.roleName}</span>
 
-							</React.Fragment>
+							</Fragment>
 
 							{
 								performer.otherRoles.length > 0 && (
@@ -32,12 +32,12 @@ export default function (props) {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}
 
-		</React.Fragment>
+		</Fragment>
 	);
 
 };

--- a/src/components/AppendedRoles.jsx
+++ b/src/components/AppendedRoles.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment, h } from 'preact';
 
 import { JoinedRoles } from '.';
 
@@ -7,13 +7,13 @@ export default function (props) {
 	const { roles } = props;
 
 	return (
-		<React.Fragment>
+		<Fragment>
 
 			<span>&nbsp;…&nbsp;</span>
 
 			<JoinedRoles instances={roles} />
 
-		</React.Fragment>
+		</Fragment>
 	);
 
 };

--- a/src/components/AppendedTheatre.jsx
+++ b/src/components/AppendedTheatre.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment, h } from 'preact';
 
 import { InstanceLink } from '.';
 
@@ -7,13 +7,13 @@ export default function (props) {
 	const { theatre } = props;
 
 	return (
-		<React.Fragment>
+		<Fragment>
 
 			<span>&nbsp;-&nbsp;</span>
 
 			<InstanceLink instance={theatre} />
 
-		</React.Fragment>
+		</Fragment>
 	);
 
 };

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function () {
 

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function (props) {
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function () {
 

--- a/src/components/InstanceFacet.jsx
+++ b/src/components/InstanceFacet.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function (props) {
 

--- a/src/components/InstanceLabel.jsx
+++ b/src/components/InstanceLabel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function (props) {
 

--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { irregularPluralNounsMap } from '../utils/constants';
 

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { InstanceLink } from '.';
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { AppendedPerformers, AppendedRoles, AppendedTheatre, InstanceLink } from '.';
 

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function () {
 

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { h } from 'preact';
 
 export default function (props) {
 

--- a/src/controllers/helpers/render-component-to-string.jsx
+++ b/src/controllers/helpers/render-component-to-string.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { renderToString } from 'react-dom/server';
+import { h } from 'preact';
+import render from 'preact-render-to-string';
 
 export default function (PageComponent, props) {
 
-	return renderToString(<PageComponent { ...props } />);
+	return render(<PageComponent { ...props } />);
 
 };

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App } from '../components';
 
-export default class ErrorPage extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle } = props;
 
-		const { documentTitle, pageTitle } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<div>This is the error page</div>
 
-				<div>This is the error page</div>
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App } from '../components';
 
-export default class Home extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle } = props;
 
-		const { documentTitle, pageTitle } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<div>This is the home page</div>
 
-				<div>This is the home page</div>
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/instances/Character.jsx
+++ b/src/pages/instances/Character.jsx
@@ -1,51 +1,47 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, InstanceFacet, JoinedRoles, List } from '../../components';
 
-export default class Character extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, character } = props;
 
-		const { documentTitle, pageTitle, character } = this.props;
+	const { model, playtexts, variantNames, productions } = character;
 
-		const { model, playtexts, variantNames, productions } = character;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+			{
+				playtexts && playtexts.length > 0 && (
+					<InstanceFacet labelText='Playtexts'>
 
-				{
-					playtexts && playtexts.length > 0 && (
-						<InstanceFacet labelText='Playtexts'>
+						<List instances={playtexts} />
 
-							<List instances={playtexts} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				variantNames && variantNames.length > 0 && (
+					<InstanceFacet labelText='Variant names'>
 
-				{
-					variantNames && variantNames.length > 0 && (
-						<InstanceFacet labelText='Variant names'>
+						<JoinedRoles instances={variantNames} />
 
-							<JoinedRoles instances={variantNames} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				productions && productions.length > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions && productions.length > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -1,31 +1,27 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default class Person extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, person } = props;
 
-		const { documentTitle, pageTitle, person } = this.props;
+	const { model, productions } = person;
 
-		const { model, productions } = person;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+			{
+				productions && productions.length > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions && productions.length > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/instances/Playtext.jsx
+++ b/src/pages/instances/Playtext.jsx
@@ -1,41 +1,37 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default class Playtext extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, playtext } = props;
 
-		const { documentTitle, pageTitle, playtext } = this.props;
+	const { model, productions, characters } = playtext;
 
-		const { model, productions, characters } = playtext;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+			{
+				productions && productions.length > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions && productions.length > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				characters && characters.length > 0 && (
+					<InstanceFacet labelText='Characters'>
 
-				{
-					characters && characters.length > 0 && (
-						<InstanceFacet labelText='Characters'>
+						<List instances={characters} />
 
-							<List instances={characters} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -1,51 +1,47 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, InstanceFacet, InstanceLink, List } from '../../components';
 
-export default class Production extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, production } = props;
 
-		const { documentTitle, pageTitle, production } = this.props;
+	const { model, theatre, playtext, cast } = production;
 
-		const { model, theatre, playtext, cast } = production;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+			{
+				theatre && (
+					<InstanceFacet labelText='Theatre'>
 
-				{
-					theatre && (
-						<InstanceFacet labelText='Theatre'>
+						<InstanceLink instance={theatre} />
 
-							<InstanceLink instance={theatre} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				playtext && (
+					<InstanceFacet labelText='Playtext'>
 
-				{
-					playtext && (
-						<InstanceFacet labelText='Playtext'>
+						<InstanceLink instance={playtext} />
 
-							<InstanceLink instance={playtext} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				cast && cast.length > 0 && (
+					<InstanceFacet labelText='Cast'>
 
-				{
-					cast && cast.length > 0 && (
-						<InstanceFacet labelText='Cast'>
+						<List instances={cast} />
 
-							<List instances={cast} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/instances/Theatre.jsx
+++ b/src/pages/instances/Theatre.jsx
@@ -1,31 +1,27 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default class Theatre extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, theatre } = props;
 
-		const { documentTitle, pageTitle, theatre } = this.props;
+	const { model, productions } = theatre;
 
-		const { model, productions } = theatre;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+			{
+				productions && productions.length > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions && productions.length > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/lists/Characters.jsx
+++ b/src/pages/lists/Characters.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, List } from '../../components';
 
-export default class Characters extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, characters } = props;
 
-		const { documentTitle, pageTitle, characters } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<List instances={characters} />
 
-				<List instances={characters} />
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/lists/People.jsx
+++ b/src/pages/lists/People.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, List } from '../../components';
 
-export default class People extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, people } = props;
 
-		const { documentTitle, pageTitle, people } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<List instances={people} />
 
-				<List instances={people} />
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/lists/Playtexts.jsx
+++ b/src/pages/lists/Playtexts.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, List } from '../../components';
 
-export default class Playtexts extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, playtexts } = props;
 
-		const { documentTitle, pageTitle, playtexts } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<List instances={playtexts} />
 
-				<List instances={playtexts} />
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/lists/Productions.jsx
+++ b/src/pages/lists/Productions.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, List } from '../../components';
 
-export default class Productions extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, productions } = props;
 
-		const { documentTitle, pageTitle, productions } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<List instances={productions} />
 
-				<List instances={productions} />
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/src/pages/lists/Theatres.jsx
+++ b/src/pages/lists/Theatres.jsx
@@ -1,21 +1,17 @@
-import React from 'react';
+import { h } from 'preact';
 
 import { App, List } from '../../components';
 
-export default class Theatres extends React.Component {
+export default function (props) {
 
-	render () {
+	const { documentTitle, pageTitle, theatres } = props;
 
-		const { documentTitle, pageTitle, theatres } = this.props;
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-		return (
-			<App documentTitle={documentTitle} pageTitle={pageTitle}>
+			<List instances={theatres} />
 
-				<List instances={theatres} />
-
-			</App>
-		);
-
-	};
+		</App>
+	);
 
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,18 @@ const serverConfig = {
 				use: {
 					loader: 'babel-loader',
 					options: {
-						presets: ['@babel/preset-env', '@babel/preset-react']
+						presets: [
+							'@babel/preset-env'
+						],
+						plugins: [
+							[
+								'@babel/plugin-transform-react-jsx',
+								{
+									pragma: 'h',
+									pragmaFrag: 'Fragment'
+								}
+							]
+						]
 					}
 
 				}


### PR DESCRIPTION
Switches React for Preact as this app is not doing anything that Preact cannot handle.

Reduces compiled server-side code form **110 KiB** to **64.1 KiB** as Preact is much more lightweight.

#### Before:
<img width="487" alt="before" src="https://user-images.githubusercontent.com/10484515/80913063-75f71200-8d39-11ea-97cc-11d66beb059a.png">

#### After:
<img width="487" alt="after" src="https://user-images.githubusercontent.com/10484515/80913049-47793700-8d39-11ea-9a46-a2d127913463.png">

### References:
- [PreactJS](https://preactjs.com).
- [PreactJS: Getting Started](https://preactjs.com/guide/v10/getting-started).
- [PreactJS: Server-Side Rendering](https://preactjs.com/guide/v10/server-side-rendering).
- [PreactJS: Components - Fragments](https://preactjs.com/guide/v10/components/#fragments).
- [PreactJS: Demos & Examples](https://preactjs.com/about/demos-examples).
- [GitHub: preactjs/preact-www (Preact documentation website)](https://github.com/preactjs/preact-www).

### New dependencies:
- [npm: preact](https://www.npmjs.com/package/preact).
- [npm: preact-render-to-string](https://www.npmjs.com/package/preact-render-to-string).

### New dev dependencies:
- [npm: @babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx).

### Removed dependencies:
- [npm: react](https://www.npmjs.com/package/react).
- [npm: react-dom](https://www.npmjs.com/package/react-dom).

### Removed dev dependencies:
- [npm: @babel/preset-react](https://www.npmjs.com/package/@babel/preset-react) (As per [Babel: @babel/preset-react](https://babeljs.io/docs/en/next/babel-preset-react.html) - "*This preset always includes the following plugins: `@babel/plugin-transform-react-jsx`*" - given we only need that package we may as well import it directly - as per new dev dependencies in this PR - and do away with this one).