### PR TITLE
Amend casing of constants

### DIFF
--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,12 +1,12 @@
 import { h } from 'preact';
 
-import { irregularPluralNounsMap } from '../utils/constants';
+import { IRREGULAR_PLURAL_NOUNS_MAP } from '../utils/constants';
 
 export default function (props) {
 
 	const { instance: { model, uuid, name } } = props;
 
-	const pluralisedModel = irregularPluralNounsMap[model] || `${model}s`;
+	const pluralisedModel = IRREGULAR_PLURAL_NOUNS_MAP[model] || `${model}s`;
 
 	const instancePath = `/${pluralisedModel}/${uuid}`;
 

--- a/src/controllers/instances.js
+++ b/src/controllers/instances.js
@@ -2,11 +2,11 @@ import sendResponse from './helpers/send-response';
 import fetchFromApi from '../lib/fetch-from-api';
 import { capitalise } from '../lib/strings';
 import { instancePages } from '../pages';
-import { irregularSingularNounsMap } from '../utils/constants';
+import { IRREGULAR_SINGULAR_NOUNS_MAP } from '../utils/constants';
 
 function getSingularFormOfModel (pluralisedModel) {
 
-	return irregularSingularNounsMap[pluralisedModel] || pluralisedModel.slice(0, -1);
+	return IRREGULAR_SINGULAR_NOUNS_MAP[pluralisedModel] || pluralisedModel.slice(0, -1);
 
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,12 +1,12 @@
-const irregularPluralNounsMap = {
+const IRREGULAR_PLURAL_NOUNS_MAP = {
 	person: 'people'
 };
 
-const irregularSingularNounsMap = {
+const IRREGULAR_SINGULAR_NOUNS_MAP = {
 	people: 'person'
 };
 
 export {
-	irregularPluralNounsMap,
-	irregularSingularNounsMap
+	IRREGULAR_PLURAL_NOUNS_MAP,
+	IRREGULAR_SINGULAR_NOUNS_MAP
 };


### PR DESCRIPTION
### References:
- [Airbnb JavaScript Style Guide](https://airbnb.io/javascript/#naming--uppercase).