### PR TITLE
Remove globals from .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,9 +4,6 @@
     "node": true
   },
   "extends": ["eslint:recommended"],
-  "globals": {
-    "fetch": false
-  },
   "parserOptions": {
       "sourceType": "module",
       "ecmaVersion": 2018


### PR DESCRIPTION
There is no reason to permit `fetch` as there is no such global used in this codebase.

Only `node-fetch` is used for fetching, and this is imported directly into the one file that uses it, i.e. it is no global.