### PR TITLE
Lint files with .jsx extension

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,10 +3,16 @@
     "es6": true,
     "node": true
   },
-  "extends": ["eslint:recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
       "sourceType": "module",
-      "ecmaVersion": 2020
+      "ecmaVersion": 2020,
+      "ecmaFeatures": {
+        "jsx": true
+      }
   },
   "rules": {
     "eqeqeq": 2,
@@ -25,6 +31,8 @@
     "no-var": 2,
     "one-var": [2, "never"],
     "quotes": [2, "single"],
+    "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0,
     "semi": 2,
     "space-before-function-paren": [2, "always"],
     "spaced-comment": 2,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Server-side rendered (SSR) application that provides listings for theatrical productions, playtexts, and associated data.",
   "main": "src/app.js",
   "scripts": {
-    "lint": "eslint --ext .js src/",
+    "lint": "eslint --ext .js,.jsx src/",
     "lintspaces": "git ls-files ':!:*.ico' | xargs lintspaces -e .editorconfig",
     "lint-check": "npm run lint && npm run lintspaces",
     "unit-test": "mocha --require @babel/register test/**/*.test.js",
@@ -36,6 +36,7 @@
     "chai": "^4.2.0",
     "css-loader": "^0.28.0",
     "eslint": "^7.5.0",
+    "eslint-plugin-react": "^7.20.3",
     "favicons-webpack-plugin": "^3.0.1",
     "lintspaces-cli": "^0.6.0",
     "mini-css-extract-plugin": "^0.9.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { Footer, Head, Header, InstanceLabel, Navigation, PageTitle } from '.';
 
-export default props => {
+const App = props => {
 
 	const { documentTitle, pageTitle, model, children } = props;
 
@@ -43,3 +43,5 @@ export default props => {
 	);
 
 };
+
+export default App;

--- a/src/components/AppendedPerformerOtherRoles.jsx
+++ b/src/components/AppendedPerformerOtherRoles.jsx
@@ -1,8 +1,8 @@
-import { Fragment, h } from 'preact';
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { JoinedRoles } from '.';
 
-export default props => {
+const AppendedPerformerOtherRoles = props => {
 
 	const { otherRoles } = props;
 
@@ -17,3 +17,5 @@ export default props => {
 	);
 
 };
+
+export default AppendedPerformerOtherRoles;

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -1,8 +1,8 @@
-import { Fragment, h } from 'preact';
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { InstanceLink, AppendedPerformerOtherRoles } from '.';
 
-export default props => {
+const AppendedPerformers = props => {
 
 	const { performers } = props;
 
@@ -41,3 +41,5 @@ export default props => {
 	);
 
 };
+
+export default AppendedPerformers;

--- a/src/components/AppendedRoles.jsx
+++ b/src/components/AppendedRoles.jsx
@@ -1,8 +1,8 @@
-import { Fragment, h } from 'preact';
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { JoinedRoles } from '.';
 
-export default props => {
+const AppendedRoles = props => {
 
 	const { roles } = props;
 
@@ -17,3 +17,5 @@ export default props => {
 	);
 
 };
+
+export default AppendedRoles;

--- a/src/components/AppendedTheatre.jsx
+++ b/src/components/AppendedTheatre.jsx
@@ -1,8 +1,8 @@
-import { Fragment, h } from 'preact';
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { InstanceLink } from '.';
 
-export default props => {
+const AppendedTheatre = props => {
 
 	const { theatre } = props;
 
@@ -17,3 +17,5 @@ export default props => {
 	);
 
 };
+
+export default AppendedTheatre;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default () => {
+const Footer = () => {
 
 	return (
 		<footer className="footer">
@@ -17,3 +17,5 @@ export default () => {
 	);
 
 };
+
+export default Footer;

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default props => {
+const Head = props => {
 
 	const { documentTitle } = props;
 
@@ -18,3 +18,5 @@ export default props => {
 	);
 
 };
+
+export default Head;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default () => {
+const Header = () => {
 
 	return (
 		<header className="header">
@@ -11,3 +11,5 @@ export default () => {
 	);
 
 };
+
+export default Header;

--- a/src/components/InstanceFacet.jsx
+++ b/src/components/InstanceFacet.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default props => {
+const InstanceFacet = props => {
 
 	const { labelText, children } = props;
 
@@ -19,3 +19,5 @@ export default props => {
 	);
 
 };
+
+export default InstanceFacet;

--- a/src/components/InstanceLabel.jsx
+++ b/src/components/InstanceLabel.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default props => {
+const InstanceLabel = props => {
 
 	const { text } = props;
 
@@ -11,3 +11,5 @@ export default props => {
 	);
 
 };
+
+export default InstanceLabel;

--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { pluralise } from '../lib/strings';
 
-export default props => {
+const InstanceLink = props => {
 
 	const { instance: { model, uuid, name } } = props;
 
@@ -17,3 +17,5 @@ export default props => {
 	);
 
 };
+
+export default InstanceLink;

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { InstanceLink } from '.';
 
-export default props => {
+const JoinedRoles = props => {
 
 	const { instances } = props;
 
@@ -25,3 +25,5 @@ export default props => {
 	);
 
 };
+
+export default JoinedRoles;

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { AppendedPerformers, AppendedRoles, AppendedTheatre, InstanceLink } from '.';
 
-export default props => {
+const List = props => {
 
 	const { instances } = props;
 
@@ -39,3 +39,5 @@ export default props => {
 	);
 
 };
+
+export default List;

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default () => {
+const Navigation = () => {
 
 	return (
 		<nav className="navigation">
@@ -25,3 +25,5 @@ export default () => {
 	);
 
 };
+
+export default Navigation;

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-export default props => {
+const PageTitle = props => {
 
 	const { text } = props;
 
@@ -11,3 +11,5 @@ export default props => {
 	);
 
 };
+
+export default PageTitle;

--- a/src/controllers/helpers/render-component-to-string.jsx
+++ b/src/controllers/helpers/render-component-to-string.jsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string';
 
 export default (PageComponent, props) => {

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App } from '../components';
 
-export default props => {
+const ErrorPage = props => {
 
 	const { documentTitle, pageTitle } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default ErrorPage;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App } from '../components';
 
-export default props => {
+const Home = props => {
 
 	const { documentTitle, pageTitle } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default Home;

--- a/src/pages/instances/Character.jsx
+++ b/src/pages/instances/Character.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, InstanceFacet, JoinedRoles, List } from '../../components';
 
-export default props => {
+const Character = props => {
 
 	const { documentTitle, pageTitle, character } = props;
 
@@ -45,3 +45,5 @@ export default props => {
 	);
 
 };
+
+export default Character;

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default props => {
+const Person = props => {
 
 	const { documentTitle, pageTitle, person } = props;
 
@@ -25,3 +25,5 @@ export default props => {
 	);
 
 };
+
+export default Person;

--- a/src/pages/instances/Playtext.jsx
+++ b/src/pages/instances/Playtext.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default props => {
+const Playtext = props => {
 
 	const { documentTitle, pageTitle, playtext } = props;
 
@@ -35,3 +35,5 @@ export default props => {
 	);
 
 };
+
+export default Playtext;

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, InstanceFacet, InstanceLink, List } from '../../components';
 
-export default props => {
+const Production = props => {
 
 	const { documentTitle, pageTitle, production } = props;
 
@@ -45,3 +45,5 @@ export default props => {
 	);
 
 };
+
+export default Production;

--- a/src/pages/instances/Theatre.jsx
+++ b/src/pages/instances/Theatre.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, InstanceFacet, List } from '../../components';
 
-export default props => {
+const Theatre = props => {
 
 	const { documentTitle, pageTitle, theatre } = props;
 
@@ -25,3 +25,5 @@ export default props => {
 	);
 
 };
+
+export default Theatre;

--- a/src/pages/lists/Characters.jsx
+++ b/src/pages/lists/Characters.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, List } from '../../components';
 
-export default props => {
+const Characters = props => {
 
 	const { documentTitle, pageTitle, characters } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default Characters;

--- a/src/pages/lists/People.jsx
+++ b/src/pages/lists/People.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, List } from '../../components';
 
-export default props => {
+const People = props => {
 
 	const { documentTitle, pageTitle, people } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default People;

--- a/src/pages/lists/Playtexts.jsx
+++ b/src/pages/lists/Playtexts.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, List } from '../../components';
 
-export default props => {
+const Playtexts = props => {
 
 	const { documentTitle, pageTitle, playtexts } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default Playtexts;

--- a/src/pages/lists/Productions.jsx
+++ b/src/pages/lists/Productions.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, List } from '../../components';
 
-export default props => {
+const Productions = props => {
 
 	const { documentTitle, pageTitle, productions } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default Productions;

--- a/src/pages/lists/Theatres.jsx
+++ b/src/pages/lists/Theatres.jsx
@@ -1,8 +1,8 @@
-import { h } from 'preact';
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { App, List } from '../../components';
 
-export default props => {
+const Theatres = props => {
 
 	const { documentTitle, pageTitle, theatres } = props;
 
@@ -15,3 +15,5 @@ export default props => {
 	);
 
 };
+
+export default Theatres;


### PR DESCRIPTION
Applies linting to files with a `.jsx` extension.

I opted for `eslint-plugin-react` even though this app uses Preact because the current options for Preact linters are:
- [`eslint-config-standard-preact`](https://github.com/zouhir/eslint-config-standard-preact): extremely opinionated about formatting.
- [`eslint-config-preact`](https://www.npmjs.com/package/eslint-config-preact): I could not get it working - it still threw a parsing error when it encountered the first opening angle brace (`<`) of a component.

The fact that this app uses Preact rather than React has required me to apply a few workarounds:
- Disable the `no-unused-vars` rule for each instance of `import { h } from 'preact';` (as `eslint-plugin-react` does not automatically excuse any Preact imports as it does for React).
- Disable `react/prop-types` in the `.eslintrc.json` file as the prop types are not enforced in a Preact context (you could assign incorrect types to values and it would not complain) and therefore serve no purpose or could even be misleading.
- Disable `react-in-jsx-scope` in the `.eslintrc.json` file as there are no imports from React in this app.

### References:
- [ESLint: Configuring ESLint](https://eslint.org/docs/6.0.0/user-guide/configuring).
- [ESLint: Command Line Interface](https://eslint.org/docs/user-guide/command-line-interface).

### New dev dependencies:
- [npm: eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react).