### PR TITLE
Apply source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --require @babel/register test/**/*.test.js",
     "build": "webpack",
     "watch": "webpack --watch",
-    "start": "nodemon built/main.js"
+    "start": "nodemon --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",
@@ -29,7 +29,8 @@
     "node-fetch": "^2.6.0",
     "preact": "^10.4.1",
     "preact-render-to-string": "^5.1.6",
-    "serve-favicon": "^2.2.0"
+    "serve-favicon": "^2.2.0",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ const serverConfig = {
 		path: path.join(__dirname, 'built'),
 		filename: 'main.js'
 	},
+	devtool: 'inline-source-map',
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
Provides reference to source code (not transpiled code) when an error is logged in the server to allow for easier debugging.

#### Before:
```
(node:18980) UnhandledPromiseRejectionWarning: ReferenceError: cosnole is not defined
    at __webpack_exports__.default (/Users/andy.gout/Documents/theatrebase-ssr/built/main.js:1294:3)
    at /Users/andy.gout/Documents/theatrebase-ssr/built/main.js:1413:125
    …
```

#### After:
```
(node:18846) UnhandledPromiseRejectionWarning: ReferenceError: cosnole is not defined
    at __webpack_exports__.default (/Users/andy.gout/Documents/theatrebase-ssr/built/webpack:/src/controllers/instances.js:11:1)
    at /Users/andy.gout/Documents/theatrebase-ssr/built/webpack:/src/router.js:19:82
    …
```