### PR TITLE
Include watch command in npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Server-side rendered (SSR) application that provides listings for theatrical pro
 - Clone this repo.
 - Set local Node version to same as listed in `package.json` `engines.node`.
 - Install node modules: `$ npm install`.
+- Compile code: `$ npm run build`.
 
 ## To run locally
-- Compile code: `$ npm run build`; compile and re-compile on change: `$ npm run watch`.
 - Ensure an instance of [`theatrebase-api`](https://github.com/andygout/theatrebase-api) is running on `http://localhost:3000`.
 - Run server using `$ npm start` and visit homepage at `http://localhost:3003`.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --require @babel/register test/**/*.test.js",
     "build": "webpack",
     "watch": "webpack --watch",
-    "start": "nodemon --require source-map-support/register built/main.js"
+    "start": "npm run watch & nodemon --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",


### PR DESCRIPTION
This will prevent the user having to have an additional CLI tab open for the purpose of watching for code changes.