### PR TITLE
Display instance differentiator

### DIFF
--- a/src/controllers/instances.js
+++ b/src/controllers/instances.js
@@ -16,11 +16,23 @@ export default async (request, response, next) => {
 
 		const model = singularise(pluralisedModel);
 
-		const title = instance.name;
+		let documentTitle = `${instance.name} (${model})`;
+
+		let pageTitle = instance.name;
+
+		if (instance.differentiator) {
+
+			const differentiatorSuffix = ` (${instance.differentiator})`;
+
+			documentTitle += differentiatorSuffix;
+
+			pageTitle += differentiatorSuffix;
+
+		}
 
 		const props = {
-			documentTitle: `${title} (${model})`,
-			pageTitle: title,
+			documentTitle,
+			pageTitle,
 			[model]: instance
 		};
 


### PR DESCRIPTION
Differentiator will now appear as part of the document title and page title.

#### Before:
<img width="666" alt="demetrius-2-before-ssr" src="https://user-images.githubusercontent.com/10484515/91830383-9dec7880-ec3a-11ea-85f4-e32e42be532a.png">

#### After:
<img width="666" alt="demetrius-2-after-ssr" src="https://user-images.githubusercontent.com/10484515/91830400-a17fff80-ec3a-11ea-8e80-9f3047abd857.png">