### PR TITLE
Prepend number differentiator with hashtag

### DIFF
--- a/src/controllers/instances.js
+++ b/src/controllers/instances.js
@@ -1,8 +1,8 @@
 import sendResponse from './helpers/send-response';
 import fetchFromApi from '../lib/fetch-from-api';
-import { capitalise } from '../lib/strings';
+import getDifferentiatorSuffix from '../lib/get-differentiator-suffix';
+import { capitalise, singularise } from '../lib/strings';
 import { instancePages } from '../pages';
-import { singularise } from '../lib/strings';
 
 export default async (request, response, next) => {
 
@@ -12,17 +12,19 @@ export default async (request, response, next) => {
 
 		const instance = await fetchFromApi(apiPath);
 
+		const { name, differentiator } = instance;
+
 		const pluralisedModel = request.path.split('/')[1];
 
 		const model = singularise(pluralisedModel);
 
-		let documentTitle = `${instance.name} (${model})`;
+		let documentTitle = `${name} (${model})`;
 
-		let pageTitle = instance.name;
+		let pageTitle = name;
 
-		if (instance.differentiator) {
+		if (differentiator) {
 
-			const differentiatorSuffix = ` (${instance.differentiator})`;
+			const differentiatorSuffix = getDifferentiatorSuffix(differentiator);
 
 			documentTitle += differentiatorSuffix;
 

--- a/src/lib/get-differentiator-suffix.js
+++ b/src/lib/get-differentiator-suffix.js
@@ -1,0 +1,9 @@
+export default differentiator => {
+
+	if (!differentiator) return '';
+
+	const differentiatorDisplayValue = isNaN(differentiator) ? differentiator : `#${differentiator}`;
+
+	return ` (${differentiatorDisplayValue})`;
+
+};

--- a/test/src/lib/get-differentiator-suffix.test.js
+++ b/test/src/lib/get-differentiator-suffix.test.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import getDifferentiatorSuffix from '../../../src/lib/get-differentiator-suffix';
+
+describe('Get Differentiator Suffix module', () => {
+
+	context('differentiator is null', () => {
+
+		it('returns empty string', () => {
+
+			expect(getDifferentiatorSuffix(null)).to.equal('');
+
+		});
+
+	});
+
+	context('differentiator is a string that is not a number', () => {
+
+		it('returns differentiator value in parentheses', () => {
+
+			expect(getDifferentiatorSuffix('foobar')).to.equal(' (foobar)');
+
+		});
+
+	});
+
+	context('differentiator is a string that is a number', () => {
+
+		it('returns differentiator value preceded by hashtag in parentheses', () => {
+
+			expect(getDifferentiatorSuffix('1')).to.equal(' (#1)');
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
Having a number in parentheses in the browser tab usually indicates a new notification or item in an inbox. Prepending the number with a hashtag makes clearer that it represents a number in a series.

#### Before:
<img width="618" alt="ssr-before" src="https://user-images.githubusercontent.com/10484515/92210644-07f95d80-ee87-11ea-8b8e-c6aeb09c432b.png">

#### After:
<img width="619" alt="ssr-after" src="https://user-images.githubusercontent.com/10484515/92210657-0c257b00-ee87-11ea-84bc-d477e6868249.png">