### PR TITLE
Display productions after characters on playtext page

### DIFF
--- a/src/pages/instances/Playtext.jsx
+++ b/src/pages/instances/Playtext.jsx
@@ -15,16 +15,6 @@ const Playtext = props => {
 		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
 			{
-				productions?.length > 0 && (
-					<InstanceFacet labelText='Productions'>
-
-						<List instances={productions} />
-
-					</InstanceFacet>
-				)
-			}
-
-			{
 				characterGroups?.length > 0 && (
 					<InstanceFacet labelText='Characters'>
 
@@ -65,6 +55,16 @@ const Playtext = props => {
 									</ul>
 								)
 						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				productions?.length > 0 && (
+					<InstanceFacet labelText='Productions'>
+
+						<List instances={productions} />
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Once writer information is added to the top of the page, it will more logically be followed by the characters in the play rather than production so of the playtext.