### PR TITLE
Apply ESLint comma-dangle rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     }
   },
   "rules": {
+    "comma-dangle": 2,
     "eqeqeq": 2,
     "guard-for-in": 2,
     "new-cap": 0,


### PR DESCRIPTION
Applies ESLint rule to prevent dangling commas.

### References:
- [ESLint: comma-dangle](https://eslint.org/docs/rules/comma-dangle)