### PR TITLE
Refactor markup

### DIFF
--- a/src/components/AppendedDepictions.jsx
+++ b/src/components/AppendedDepictions.jsx
@@ -14,19 +14,19 @@ const AppendedDepictions = props => {
 
 							{
 								depiction.displayName && (
-									<span> (as <span className="role-text">{ depiction.displayName }</span>)</span>
+									<Fragment>&nbsp;(as <span className="role-text">{ depiction.displayName }</span>)</Fragment>
 								)
 							}
 
 							{
 								depiction.qualifier && (
-									<span> ({ depiction.qualifier })</span>
+									<Fragment>&nbsp;({ depiction.qualifier })</Fragment>
 								)
 							}
 
 							{
 								depiction.group && (
-									<span> ({ depiction.group })</span>
+									<Fragment>&nbsp;({ depiction.group })</Fragment>
 								)
 							}
 

--- a/src/components/AppendedPerformerOtherRoles.jsx
+++ b/src/components/AppendedPerformerOtherRoles.jsx
@@ -9,7 +9,7 @@ const AppendedPerformerOtherRoles = props => {
 	return (
 		<Fragment>
 
-			<span>; also performed:&nbsp;</span>
+			<Fragment>; also performed:&nbsp;</Fragment>
 
 			<JoinedRoles instances={otherRoles} />
 

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -9,7 +9,7 @@ const AppendedPerformers = props => {
 	return (
 		<Fragment>
 
-			<span>&nbsp;- performed by:&nbsp;</span>
+			<Fragment>&nbsp;- performed by:&nbsp;</Fragment>
 
 			{
 				performers
@@ -20,7 +20,7 @@ const AppendedPerformers = props => {
 
 								<InstanceLink instance={performer} />
 
-								<span>&nbsp;…&nbsp;</span>
+								<Fragment>&nbsp;…&nbsp;</Fragment>
 
 								<span className="role-text">
 									{
@@ -28,7 +28,7 @@ const AppendedPerformers = props => {
 									}
 									{
 										performer.qualifier && (
-											<span> ({ performer.qualifier })</span>
+											<Fragment>&nbsp;({ performer.qualifier })</Fragment>
 										)
 									}
 								</span>

--- a/src/components/AppendedRoles.jsx
+++ b/src/components/AppendedRoles.jsx
@@ -9,7 +9,7 @@ const AppendedRoles = props => {
 	return (
 		<Fragment>
 
-			<span>&nbsp;…&nbsp;</span>
+			<Fragment>&nbsp;…&nbsp;</Fragment>
 
 			<JoinedRoles instances={roles} />
 

--- a/src/components/AppendedSubTheatres.jsx
+++ b/src/components/AppendedSubTheatres.jsx
@@ -7,7 +7,10 @@ const AppendedSubTheatres = props => {
 	const { subTheatres } = props;
 
 	return (
-		<Fragment>:&nbsp;
+		<Fragment>
+
+			<Fragment>:&nbsp;</Fragment>
+
 			{
 				subTheatres
 					.map((subTheatre, index) =>
@@ -15,6 +18,7 @@ const AppendedSubTheatres = props => {
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}
+
 		</Fragment>
 	);
 

--- a/src/components/AppendedTheatre.jsx
+++ b/src/components/AppendedTheatre.jsx
@@ -9,11 +9,11 @@ const AppendedTheatre = props => {
 	return (
 		<Fragment>
 
-			<span>&nbsp;-&nbsp;</span>
+			<Fragment>&nbsp;-&nbsp;</Fragment>
 
 			{
 				theatre.surTheatre && (
-					<span><InstanceLink instance={theatre.surTheatre} />: </span>
+					<Fragment><InstanceLink instance={theatre.surTheatre} />:&nbsp;</Fragment>
 				)
 			}
 

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -1,4 +1,4 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { InstanceLink } from '.';
 
@@ -11,7 +11,7 @@ const JoinedRoles = props => {
 			{
 				instances
 					.map((instance, index) =>
-						<span key={index}>
+						<Fragment key={index}>
 							{
 								instance.uuid
 									? <InstanceLink instance={instance} />
@@ -19,10 +19,10 @@ const JoinedRoles = props => {
 							}
 							{
 								instance.qualifier && (
-									<span> ({ instance.qualifier })</span>
+									<Fragment>&nbsp;({ instance.qualifier })</Fragment>
 								)
 							}
-						</span>
+						</Fragment>
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,4 +1,4 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import {
 	AppendedDepictions,
@@ -23,7 +23,7 @@ const List = props => {
 						{
 							instance.uuid
 								? <InstanceLink instance={instance} />
-								: <span>{ instance.name }</span>
+								: <Fragment>{ instance.name }</Fragment>
 						}
 
 						{
@@ -70,7 +70,7 @@ const List = props => {
 
 						{
 							instance.qualifier && (
-								<span> ({instance.qualifier})</span>
+								<Fragment>&nbsp;({instance.qualifier})</Fragment>
 							)
 						}
 


### PR DESCRIPTION
- Replaces `span` tags with `Fragment` tags to avoid unnecessary markup.
- Makes usage of `&nbsp;` more consistent.