### PR TITLE
Display playtext original/subsequent version playtexts

### DIFF
--- a/src/pages/instances/Playtext.jsx
+++ b/src/pages/instances/Playtext.jsx
@@ -1,12 +1,19 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, List, WriterGroups } from '../../components';
+import { App, AppendedWriterGroups, InstanceFacet, InstanceLink, List, WriterGroups } from '../../components';
 
 const Playtext = props => {
 
 	const { documentTitle, pageTitle, playtext } = props;
 
-	const { model, writerGroups, productions, characterGroups } = playtext;
+	const {
+		model,
+		writerGroups,
+		characterGroups,
+		originalVersionPlaytext,
+		subsequentVersionPlaytexts,
+		productions
+	} = playtext;
 
 	const instanceFacetSubheader = subheaderText =>
 		<div className="instance-facet-subheader">{ subheaderText }</div>;
@@ -65,6 +72,32 @@ const Playtext = props => {
 									</ul>
 								)
 						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				originalVersionPlaytext && (
+					<InstanceFacet labelText='Original version'>
+
+						<InstanceLink instance={originalVersionPlaytext} />
+
+						{
+							originalVersionPlaytext.writerGroups?.length > 0 && (
+								<AppendedWriterGroups writerGroups={originalVersionPlaytext.writerGroups} />
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subsequentVersionPlaytexts?.length > 0 && (
+					<InstanceFacet labelText='Subsequent versions'>
+
+						<List instances={subsequentVersionPlaytexts} />
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Display playtext original/subsequent version playtexts data exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/310.

#### The Seagull (original version) (playtext)
N.B. Displayed text to be amended in future so that it reads more logically.
![the-seagull-original-version-playtext](https://user-images.githubusercontent.com/10484515/102018388-e3a1fc80-3d64-11eb-94e8-7b233d1ccf50.png)

---

#### The Seagull (subsequent version) (playtext)
![the-seagull-subsequent-version-playtext](https://user-images.githubusercontent.com/10484515/102018399-ef8dbe80-3d64-11eb-97f5-bba4a8bebc32.png)