### PR TITLE
Amend .map() syntax

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -17,7 +17,7 @@ const List = props => {
 	return (
 		<ul className="list">
 			{
-				instances.map((instance, index) => (
+				instances.map((instance, index) =>
 					<li key={index}>
 
 						{
@@ -75,7 +75,7 @@ const List = props => {
 						}
 
 					</li>
-				))
+				)
 			}
 		</ul>
 	);

--- a/src/pages/instances/Playtext.jsx
+++ b/src/pages/instances/Playtext.jsx
@@ -56,7 +56,7 @@ const Playtext = props => {
 									<ul className="list list--no-bullets">
 
 										{
-											characterGroups.map((characterGroup, index) => (
+											characterGroups.map((characterGroup, index) =>
 												<li key={index} className="instance-facet-group">
 
 													{
@@ -68,7 +68,7 @@ const Playtext = props => {
 													<List instances={characterGroup.characters} />
 
 												</li>
-											))
+											)
 										}
 
 									</ul>


### PR DESCRIPTION
Remove unnecessary curly braces and parentheses when using implicit return statement.