### PR TITLE
Revise Boolean determination

### DIFF
--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -63,7 +63,7 @@ const Material = props => {
 									<Fragment>
 
 										{
-											!!characterGroups[0].name && (
+											Boolean(characterGroups[0].name) && (
 												instanceFacetSubheader(characterGroups[0].name)
 											)
 										}
@@ -80,7 +80,7 @@ const Material = props => {
 												<li key={index} className="instance-facet-group">
 
 													{
-														!!characterGroup.name && (
+														Boolean(characterGroup.name) && (
 															instanceFacetSubheader(characterGroup.name)
 														)
 													}


### PR DESCRIPTION
The double negation shorthand of `!!` to evaluate an expression into `true`/`false` is not as intuitive as `Boolean()`, so this PR makes changes to use the latter throughout the code.