### PR TITLE
Disable react/display-name linting rule for single line

### DIFF
--- a/src/controllers/helpers/render-component-to-string.jsx
+++ b/src/controllers/helpers/render-component-to-string.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string';
 
-export default (PageComponent, props) => {
+export default (PageComponent, props) => { // eslint-disable-line react/display-name
 
 	return render(<PageComponent { ...props } />);
 


### PR DESCRIPTION
This PR disables the `react/display-name` linting rule for a single line which is currently causing [CI builds to fail](https://app.circleci.com/pipelines/github/andygout/theatrebase-ssr/300/workflows/46c94109-bed9-4ab8-8387-7e3fedfadc2d/jobs/1573) (though cannot be replicated locally):

```
/home/circleci/project/src/controllers/helpers/render-component-to-string.jsx
  4:16  error  Component definition is missing display name  react/display-name
```

### References:
- [GitHub: yannickcr/eslint-plugin-react - Rule Details](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md#user-content-rule-details)