### PR TITLE
Add award ceremonies resource

### DIFF
--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,14 +1,12 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { pluralise } from '../lib/strings';
+import { getRouteFromModel } from '../lib/get-route';
 
 const InstanceLink = props => {
 
 	const { instance: { model, uuid, name } } = props;
 
-	const pluralisedModel = pluralise(model);
-
-	const instancePath = `/${pluralisedModel}/${uuid}`;
+	const instancePath = `/${getRouteFromModel(model)}/${uuid}`;
 
 	return (
 		<a href={instancePath}>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -12,6 +12,7 @@ import {
 	AppendedSubVenues,
 	AppendedVenue,
 	AppendedWritingCredits,
+	PrependedAward,
 	InstanceLink
 } from '.';
 
@@ -25,6 +26,12 @@ const List = props => {
 			{
 				instances.map((instance, index) =>
 					<li key={index}>
+
+						{
+							instance.award && (
+								<PrependedAward award={instance.award} />
+							)
+						}
 
 						{
 							instance.uuid

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -11,6 +11,8 @@ const Navigation = () => {
 
 				<li><a href='/awards'>Awards</a></li>
 
+				<li><a href='/awards/ceremonies'>Award ceremonies</a></li>
+
 				<li><a href='/characters'>Characters</a></li>
 
 				<li><a href='/companies'>Companies</a></li>

--- a/src/components/PrependedAward.jsx
+++ b/src/components/PrependedAward.jsx
@@ -1,0 +1,21 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { InstanceLink } from '.';
+
+const PrependedAward = props => {
+
+	const { award } = props;
+
+	return (
+		<Fragment>
+
+			<InstanceLink instance={award} />
+
+			<Fragment>:&nbsp;</Fragment>
+
+		</Fragment>
+	);
+
+};
+
+export default PrependedAward;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import JoinedRoles from './JoinedRoles';
 import List from './List';
 import Navigation from './Navigation';
 import PageTitle from './PageTitle';
+import PrependedAward from './PrependedAward';
 import PrependedCreditedMembers from './PrependedCreditedMembers';
 import ProducerCredits from './ProducerCredits';
 import ProducerEntities from './ProducerEntities';
@@ -61,6 +62,7 @@ export {
 	List,
 	Navigation,
 	PageTitle,
+	PrependedAward,
 	PrependedCreditedMembers,
 	ProducerCredits,
 	ProducerEntities,

--- a/src/controllers/instances.js
+++ b/src/controllers/instances.js
@@ -1,7 +1,8 @@
 import sendResponse from './helpers/send-response';
 import fetchFromApi from '../lib/fetch-from-api';
 import getDifferentiatorSuffix from '../lib/get-differentiator-suffix';
-import { capitalise, singularise } from '../lib/strings';
+import { getModelFromRoute } from '../lib/get-model';
+import { pascalCasify } from '../lib/strings';
 import { instancePages } from '../pages';
 
 export default async (request, response, next) => {
@@ -14,9 +15,13 @@ export default async (request, response, next) => {
 
 		const { name, differentiator } = instance;
 
-		const pluralisedModel = request.path.split('/')[1];
+		const modelRoute =
+			request.route.path.split('/')
+				.filter(routeComponent => routeComponent !== ':uuid')
+				.filter(Boolean)
+				.join('/');
 
-		const model = singularise(pluralisedModel);
+		const model = getModelFromRoute(modelRoute);
 
 		let documentTitle = `${name} (${model})`;
 
@@ -38,7 +43,7 @@ export default async (request, response, next) => {
 			[model]: instance
 		};
 
-		const PageComponent = instancePages[capitalise(model)];
+		const PageComponent = instancePages[pascalCasify(model)];
 
 		return sendResponse(response, PageComponent, props);
 

--- a/src/controllers/lists.js
+++ b/src/controllers/lists.js
@@ -1,6 +1,7 @@
 import sendResponse from './helpers/send-response';
 import fetchFromApi from '../lib/fetch-from-api';
-import { capitalise } from '../lib/strings';
+import { getPluralisedModelFromRoute } from '../lib/get-model';
+import { pascalCasify } from '../lib/strings';
 import { listPages } from '../pages';
 
 export default async (request, response, next) => {
@@ -11,9 +12,15 @@ export default async (request, response, next) => {
 
 		const list = await fetchFromApi(apiPath);
 
-		const pluralisedModel = request.path.split('/')[1];
+		const modelRoute =
+			request.route.path.split('/')
+				.filter(routeComponent => routeComponent !== ':uuid')
+				.filter(Boolean)
+				.join('/');
 
-		const title = capitalise(pluralisedModel);
+		const pluralisedModel = getPluralisedModelFromRoute(modelRoute);
+
+		const title = pascalCasify(pluralisedModel);
 
 		const props = {
 			documentTitle: title,
@@ -21,7 +28,7 @@ export default async (request, response, next) => {
 			[pluralisedModel]: list
 		};
 
-		const PageComponent = listPages[capitalise(pluralisedModel)];
+		const PageComponent = listPages[pascalCasify(pluralisedModel)];
 
 		return sendResponse(response, PageComponent, props);
 

--- a/src/lib/get-model.js
+++ b/src/lib/get-model.js
@@ -1,0 +1,11 @@
+import { singularise } from './strings';
+import { ROUTE_TO_PLURALISED_MODEL_MAP, ROUTE_TO_MODEL_MAP } from '../utils/constants';
+
+const getModelFromRoute = route => ROUTE_TO_MODEL_MAP[route] || singularise(route);
+
+const getPluralisedModelFromRoute = route => ROUTE_TO_PLURALISED_MODEL_MAP[route] || route;
+
+export {
+	getModelFromRoute,
+	getPluralisedModelFromRoute
+};

--- a/src/lib/get-route.js
+++ b/src/lib/get-route.js
@@ -1,0 +1,9 @@
+import { pluralise } from './strings';
+import { MODEL_TO_ROUTE_MAP } from '../utils/constants';
+
+const getRouteFromModel = model =>
+	MODEL_TO_ROUTE_MAP[model] || pluralise(model);
+
+export {
+	getRouteFromModel
+};

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -5,12 +5,15 @@ import {
 
 const capitalise = string => string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
 
+const pascalCasify = string => string.charAt(0).toUpperCase() + string.substring(1);
+
 const pluralise = model => IRREGULAR_PLURAL_NOUNS_MAP[model] || `${model}s`;
 
 const singularise = pluralisedModel => IRREGULAR_SINGULAR_NOUNS_MAP[pluralisedModel] || pluralisedModel.slice(0, -1);
 
 export {
 	capitalise,
+	pascalCasify,
 	pluralise,
 	singularise
 };

--- a/src/pages/instances/Award.jsx
+++ b/src/pages/instances/Award.jsx
@@ -1,15 +1,27 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App } from '../../components';
+import { App, InstanceFacet, List } from '../../components';
 
 const Award = props => {
 
 	const { documentTitle, pageTitle, award } = props;
 
-	const { model } = award;
+	const { model, awardCeremonies } = award;
 
 	return (
-		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model} />
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+
+			{
+				awardCeremonies?.length > 0 && (
+					<InstanceFacet labelText='Ceremonies'>
+
+						<List instances={awardCeremonies} />
+
+					</InstanceFacet>
+				)
+			}
+
+		</App>
 	);
 
 };

--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -1,0 +1,29 @@
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { App, InstanceFacet, InstanceLink } from '../../components';
+
+const AwardCeremony = props => {
+
+	const { documentTitle, pageTitle, awardCeremony } = props;
+
+	const { model, award } = awardCeremony;
+
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+
+			{
+				award && (
+					<InstanceFacet labelText='Award'>
+
+						<InstanceLink instance={award} />
+
+					</InstanceFacet>
+				)
+			}
+
+		</App>
+	);
+
+};
+
+export default AwardCeremony;

--- a/src/pages/instances/index.js
+++ b/src/pages/instances/index.js
@@ -1,4 +1,5 @@
 import Award from './Award';
+import AwardCeremony from './AwardCeremony';
 import Character from './Character';
 import Company from './Company';
 import Material from './Material';
@@ -8,6 +9,7 @@ import Venue from './Venue';
 
 export {
 	Award,
+	AwardCeremony,
 	Character,
 	Company,
 	Material,

--- a/src/pages/lists/AwardCeremonies.jsx
+++ b/src/pages/lists/AwardCeremonies.jsx
@@ -1,0 +1,19 @@
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { App, List } from '../../components';
+
+const AwardCeremonies = props => {
+
+	const { documentTitle, pageTitle, awardCeremonies } = props;
+
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
+
+			<List instances={awardCeremonies} />
+
+		</App>
+	);
+
+};
+
+export default AwardCeremonies;

--- a/src/pages/lists/index.js
+++ b/src/pages/lists/index.js
@@ -1,4 +1,5 @@
 import Awards from './Awards';
+import AwardCeremonies from './AwardCeremonies';
 import Characters from './Characters';
 import Companies from './Companies';
 import Materials from './Materials';
@@ -8,6 +9,7 @@ import Venues from './Venues';
 
 export {
 	Awards,
+	AwardCeremonies,
 	Characters,
 	Companies,
 	Materials,

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,8 @@ import {
 const router = new Router();
 
 router.get('/', (request, response) => homeController(response));
+router.get('/awards/ceremonies', (request, response, next) => listsController(request, response, next));
+router.get('/awards/ceremonies/:uuid', (request, response, next) => instancesController(request, response, next));
 router.get('/awards', (request, response, next) => listsController(request, response, next));
 router.get('/awards/:uuid', (request, response, next) => instancesController(request, response, next));
 router.get('/characters', (request, response, next) => listsController(request, response, next));

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,7 +8,22 @@ const IRREGULAR_SINGULAR_NOUNS_MAP = {
 	people: 'person'
 };
 
+const MODEL_TO_ROUTE_MAP = {
+	awardCeremony: 'awards/ceremonies'
+};
+
+const ROUTE_TO_MODEL_MAP = {
+	'awards/ceremonies': 'awardCeremony'
+};
+
+const ROUTE_TO_PLURALISED_MODEL_MAP = {
+	'awards/ceremonies': 'awardCeremonies'
+};
+
 export {
 	IRREGULAR_PLURAL_NOUNS_MAP,
-	IRREGULAR_SINGULAR_NOUNS_MAP
+	IRREGULAR_SINGULAR_NOUNS_MAP,
+	MODEL_TO_ROUTE_MAP,
+	ROUTE_TO_MODEL_MAP,
+	ROUTE_TO_PLURALISED_MODEL_MAP
 };

--- a/test/src/lib/get-model.test.js
+++ b/test/src/lib/get-model.test.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+
+import { getModelFromRoute, getPluralisedModelFromRoute } from '../../../src/lib/get-model';
+
+describe('Get Model module', () => {
+
+	describe('getModelFromRoute function', () => {
+
+		context('model can be acquired by converting route to singular form', () => {
+
+			it('returns route with tailing \'s\' removed', () => {
+
+				expect(getModelFromRoute('productions')).to.equal('production');
+
+			});
+
+		});
+
+		context('route requires mapping to acquire model', () => {
+
+			it('returns model name', () => {
+
+				const models = [
+					{ name: 'awardCeremony', route: 'awards/ceremonies' }
+				];
+
+				models.forEach(model => {
+
+					expect(getModelFromRoute(model.route)).to.equal(model.name);
+
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('getPluralisedModelFromRoute function', () => {
+
+		context('route is the same as pluralised model', () => {
+
+			it('returns route', () => {
+
+				expect(getPluralisedModelFromRoute('productions')).to.equal('productions');
+
+			});
+
+		});
+
+		context('route requires mapping to acquire pluralised model', () => {
+
+			it('returns pluralised model name', () => {
+
+				const pluralisedModels = [
+					{ name: 'awardCeremonies', route: 'awards/ceremonies' }
+				];
+
+				pluralisedModels.forEach(pluralisedModel => {
+
+					expect(getPluralisedModelFromRoute(pluralisedModel.route)).to.equal(pluralisedModel.name);
+
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/src/lib/get-route.test.js
+++ b/test/src/lib/get-route.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import { getRouteFromModel } from '../../../src/lib/get-route';
+
+describe('Get Route module', () => {
+
+	describe('getRouteFromModel function', () => {
+
+		context('route can be acquired by converting model to plural form', () => {
+
+			it('returns model with tailing \'s\' added', () => {
+
+				expect(getRouteFromModel('production')).to.equal('productions');
+
+			});
+
+		});
+
+		context('model requires mapping to acquire route', () => {
+
+			it('returns route', () => {
+
+				const models = [
+					{ name: 'awardCeremony', route: 'awards/ceremonies' }
+				];
+
+				models.forEach(model => {
+
+					expect(getRouteFromModel(model.name)).to.equal(model.route);
+
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/src/lib/strings.test.js
+++ b/test/src/lib/strings.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { capitalise, pluralise, singularise } from '../../../src/lib/strings';
+import { capitalise, pascalCasify, pluralise, singularise } from '../../../src/lib/strings';
 
 describe('Strings module', () => {
 
@@ -21,6 +21,30 @@ describe('Strings module', () => {
 			it('returns string with initial letter as capital', () => {
 
 				expect(capitalise('STRING')).to.equal('String');
+
+			});
+
+		});
+
+	});
+
+	describe('pascalCasify function', () => {
+
+		context('input string is lowercase', () => {
+
+			it('returns string with initial letter as capital', () => {
+
+				expect(pascalCasify('foo')).to.equal('Foo');
+
+			});
+
+		});
+
+		context('input string is camel case', () => {
+
+			it('returns string with initial letter as capital', () => {
+
+				expect(pascalCasify('fooBar')).to.equal('FooBar');
 
 			});
 


### PR DESCRIPTION
This PR adds functionality to display award ceremony data added in this API PR: https://github.com/andygout/theatrebase-api/pull/435.

---

#### Award ceremonies list
<img width="327" alt="award-ceremonies-list" src="https://user-images.githubusercontent.com/10484515/131254826-5eaaa24b-f15e-4780-9b84-d601721544d3.png">

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="191" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/131254822-c0a8cc2d-55e7-4ec0-bb16-da2abe25ced6.png">