### PR TITLE
Revise award ceremony instance title

### DIFF
--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -8,6 +8,10 @@ export default instance => {
 
 	switch (instance.model) {
 
+		case MODELS.AWARD_CEREMONY:
+			if (instance.award) title = `${instance.award.name} ${title}`;
+			return title;
+
 		case MODELS.VENUE:
 			if (instance.surVenue) title = `${instance.surVenue.name}: ${title}`;
 			return title;

--- a/test/src/lib/get-instance-title.test.js
+++ b/test/src/lib/get-instance-title.test.js
@@ -4,6 +4,44 @@ import getInstanceTitle from '../../../src/lib/get-instance-title';
 
 describe('Get Instance Title module', () => {
 
+	context('instance model is AWARD_CEREMONY', () => {
+
+		context('instance does not have an award', () => {
+
+			it('returns requisite title', () => {
+
+				const instance = {
+					model: 'AWARD_CEREMONY',
+					name: '2020',
+					award: null
+				};
+
+				expect(getInstanceTitle(instance)).to.equal('2020');
+
+			});
+
+		});
+
+		context('instance has an award', () => {
+
+			it('returns requisite title', () => {
+
+				const instance = {
+					model: 'AWARD_CEREMONY',
+					name: '2020',
+					award: {
+						name: 'Laurence Olivier Awards'
+					}
+				};
+
+				expect(getInstanceTitle(instance)).to.equal('Laurence Olivier Awards 2020');
+
+			});
+
+		});
+
+	});
+
 	context('instance model is VENUE', () => {
 
 		context('instance does not have a surVenue', () => {


### PR DESCRIPTION
The page and document title for award ceremony instances is now prefixed with the award name, if available, e.g.

#### Before
2020

#### After
Laurence Olivier Awards 2020