### PR TITLE
Display award ceremony categories

### DIFF
--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -1,12 +1,12 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, InstanceLink } from '../../components';
+import { App, InstanceFacet, InstanceLink, List } from '../../components';
 
 const AwardCeremony = props => {
 
 	const { documentTitle, pageTitle, awardCeremony } = props;
 
-	const { model, award } = awardCeremony;
+	const { model, award, categories } = awardCeremony;
 
 	return (
 		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
@@ -16,6 +16,16 @@ const AwardCeremony = props => {
 					<InstanceFacet labelText='Award'>
 
 						<InstanceLink instance={award} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				categories?.length > 0 && (
+					<InstanceFacet labelText='Categories'>
+
+						<List instances={categories} />
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Display award ceremony categories exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/447.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="491" alt="award-ceremony-category" src="https://user-images.githubusercontent.com/10484515/133154948-1c1498a5-cc24-4d05-8bdf-ab4c9e8b6f25.png">