### PR TITLE
Display award ceremony category nomination entities

### DIFF
--- a/src/components/AppendedCoNominatedEntities.jsx
+++ b/src/components/AppendedCoNominatedEntities.jsx
@@ -1,0 +1,23 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { NominatedEntities } from '.';
+
+const AppendedCoNominatedEntities = props => {
+
+	const { coNominatedEntities } = props;
+
+	return (
+		<Fragment>
+
+			<Fragment>&nbsp;(with&nbsp;</Fragment>
+
+			<NominatedEntities nominatedEntities={coNominatedEntities} />
+
+			<Fragment>)</Fragment>
+
+		</Fragment>
+	);
+
+};
+
+export default AppendedCoNominatedEntities;

--- a/src/components/AppendedNominatedEmployerCompany.jsx
+++ b/src/components/AppendedNominatedEmployerCompany.jsx
@@ -1,0 +1,39 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { CommaSeparatedInstanceLinks, InstanceLink } from '.';
+
+const AppendedNominatedEmployerCompany = props => {
+
+	const { nominatedEmployerCompany } = props;
+
+	return (
+		<Fragment>
+
+			<Fragment>&nbsp;(</Fragment>
+
+			{
+				nominatedEmployerCompany.coNominatedMembers?.length > 0 && (
+					<Fragment>
+
+						<Fragment>with&nbsp;</Fragment>
+
+						<CommaSeparatedInstanceLinks instances={nominatedEmployerCompany.coNominatedMembers} />
+
+						<Fragment>&nbsp;</Fragment>
+
+					</Fragment>
+				)
+			}
+
+			<Fragment>for&nbsp;</Fragment>
+
+			<InstanceLink instance={nominatedEmployerCompany} />
+
+			<Fragment>)</Fragment>
+
+		</Fragment>
+	);
+
+};
+
+export default AppendedNominatedEmployerCompany;

--- a/src/components/AppendedNominatedMembers.jsx
+++ b/src/components/AppendedNominatedMembers.jsx
@@ -1,0 +1,23 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { CommaSeparatedInstanceLinks } from '.';
+
+const AppendedNominatedMembers = props => {
+
+	const { nominatedMembers } = props;
+
+	return (
+		<Fragment>
+
+			<Fragment>&nbsp;(</Fragment>
+
+			<CommaSeparatedInstanceLinks instances={nominatedMembers} />
+
+			<Fragment>)</Fragment>
+
+		</Fragment>
+	);
+
+};
+
+export default AppendedNominatedMembers;

--- a/src/components/NominatedEntities.jsx
+++ b/src/components/NominatedEntities.jsx
@@ -1,0 +1,35 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { AppendedNominatedMembers, InstanceLink } from '.';
+
+const NominatedEntities = props => {
+
+	const { nominatedEntities } = props;
+
+	return (
+		<Fragment>
+
+			{
+				nominatedEntities
+					.map((nominatedEntity, index) =>
+						<Fragment key={index}>
+
+							<InstanceLink instance={nominatedEntity} />
+
+							{
+								nominatedEntity.nominatedMembers?.length > 0 && (
+									<AppendedNominatedMembers nominatedMembers={nominatedEntity.nominatedMembers} />
+								)
+							}
+
+						</Fragment>
+					)
+					.reduce((prev, curr) => [prev, ', ', curr])
+			}
+
+		</Fragment>
+	);
+
+};
+
+export default NominatedEntities;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,10 +1,13 @@
 import App from './App';
 import AppendedCoCreditedEntities from './AppendedCoCreditedEntities';
+import AppendedCoNominatedEntities from './AppendedCoNominatedEntities';
 import AppendedCreditedEmployerCompany from './AppendedCreditedEmployerCompany';
 import AppendedCreditedMembers from './AppendedCreditedMembers';
 import AppendedDepictions from './AppendedDepictions';
 import AppendedEntities from './AppendedEntities';
 import AppendedFormatAndYear from './AppendedFormatAndYear';
+import AppendedNominatedEmployerCompany from './AppendedNominatedEmployerCompany';
+import AppendedNominatedMembers from './AppendedNominatedMembers';
 import AppendedPerformers from './AppendedPerformers';
 import AppendedPerformerOtherRoles from './AppendedPerformerOtherRoles';
 import AppendedProductionDates from './AppendedProductionDates';
@@ -25,6 +28,7 @@ import InstanceLink from './InstanceLink';
 import JoinedRoles from './JoinedRoles';
 import List from './List';
 import Navigation from './Navigation';
+import NominatedEntities from './NominatedEntities';
 import PageTitle from './PageTitle';
 import PrependedAward from './PrependedAward';
 import PrependedCreditedMembers from './PrependedCreditedMembers';
@@ -36,11 +40,14 @@ import WritingEntities from './WritingEntities';
 export {
 	App,
 	AppendedCoCreditedEntities,
+	AppendedCoNominatedEntities,
 	AppendedCreditedEmployerCompany,
 	AppendedCreditedMembers,
 	AppendedDepictions,
 	AppendedEntities,
 	AppendedFormatAndYear,
+	AppendedNominatedEmployerCompany,
+	AppendedNominatedMembers,
 	AppendedPerformers,
 	AppendedPerformerOtherRoles,
 	AppendedProductionDates,
@@ -61,6 +68,7 @@ export {
 	JoinedRoles,
 	List,
 	Navigation,
+	NominatedEntities,
 	PageTitle,
 	PrependedAward,
 	PrependedCreditedMembers,

--- a/src/pages/instances/Award.jsx
+++ b/src/pages/instances/Award.jsx
@@ -6,16 +6,16 @@ const Award = props => {
 
 	const { documentTitle, pageTitle, award } = props;
 
-	const { model, awardCeremonies } = award;
+	const { model, ceremonies } = award;
 
 	return (
 		<App documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
 
 			{
-				awardCeremonies?.length > 0 && (
+				ceremonies?.length > 0 && (
 					<InstanceFacet labelText='Ceremonies'>
 
-						<List instances={awardCeremonies} />
+						<List instances={ceremonies} />
 
 					</InstanceFacet>
 				)

--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, InstanceLink, List } from '../../components';
+import { App, InstanceFacet, InstanceLink, NominatedEntities } from '../../components';
 
 const AwardCeremony = props => {
 
@@ -25,7 +25,25 @@ const AwardCeremony = props => {
 				categories?.length > 0 && (
 					<InstanceFacet labelText='Categories'>
 
-						<List instances={categories} />
+						{
+							categories.map((category, index) =>
+								<Fragment key={index}>
+									{ category.name }
+
+									<ul className="list">
+
+										{
+											category.nominations.map((nomination, index) =>
+												<li key={index}>
+													<NominatedEntities nominatedEntities={nomination.entities} />
+												</li>
+											)
+										}
+
+									</ul>
+								</Fragment>
+							)
+						}
 
 					</InstanceFacet>
 				)

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -1,6 +1,13 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, List } from '../../components';
+import {
+	App,
+	AppendedCoNominatedEntities,
+	AppendedNominatedMembers,
+	InstanceFacet,
+	InstanceLink,
+	List
+} from '../../components';
 
 const Company = props => {
 
@@ -14,7 +21,8 @@ const Company = props => {
 		rightsGrantorMaterials,
 		producerProductions,
 		creativeProductions,
-		crewProductions
+		crewProductions,
+		awards
 	} = company;
 
 	return (
@@ -85,6 +93,70 @@ const Company = props => {
 					<InstanceFacet labelText='Productions as crew member'>
 
 						<List instances={crewProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				awards?.length > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.ceremonies.map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.categories
+															.map((category, index) =>
+																<Fragment key={index}>
+																	{ category.name }{': '}
+
+																	{
+																		category.nominations
+																			.map((nomination, index) =>
+																				<Fragment key={index}>
+																					{'Nomination'}
+
+																					{
+																						nomination.nominatedMembers?.length > 0 && (
+																							<AppendedNominatedMembers
+																								nominatedMembers={nomination.nominatedMembers}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.coNominatedEntities.length > 0 && (
+																							<AppendedCoNominatedEntities
+																								coNominatedEntities={nomination.coNominatedEntities}
+																							/>
+																						)
+																					}
+																				</Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</Fragment>
+							)
+						}
 
 					</InstanceFacet>
 				)

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -1,6 +1,13 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, List } from '../../components';
+import {
+	App,
+	AppendedNominatedEmployerCompany,
+	AppendedCoNominatedEntities,
+	InstanceFacet,
+	InstanceLink,
+	List
+} from '../../components';
 
 const Person = props => {
 
@@ -15,7 +22,8 @@ const Person = props => {
 		producerProductions,
 		castMemberProductions,
 		creativeProductions,
-		crewProductions
+		crewProductions,
+		awards
 	} = person;
 
 	return (
@@ -96,6 +104,70 @@ const Person = props => {
 					<InstanceFacet labelText='Productions as crew member'>
 
 						<List instances={crewProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				awards?.length > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.ceremonies.map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.categories
+															.map((category, index) =>
+																<Fragment key={index}>
+																	{ category.name }{': '}
+
+																	{
+																		category.nominations
+																			.map((nomination, index) =>
+																				<Fragment key={index}>
+																					{'Nomination'}
+
+																					{
+																						nomination.nominatedEmployerCompany && (
+																							<AppendedNominatedEmployerCompany
+																								nominatedEmployerCompany={nomination.nominatedEmployerCompany}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.coNominatedEntities.length > 0 && (
+																							<AppendedCoNominatedEntities
+																								coNominatedEntities={nomination.coNominatedEntities}
+																							/>
+																						)
+																					}
+																				</Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</Fragment>
+							)
+						}
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Display award ceremony category nomination entities exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/448.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="823" alt="laurence-olivier-awards-2020" src="https://user-images.githubusercontent.com/10484515/141331773-ba37ef09-ff06-43fa-bad6-3164d8bee19c.png">

---

#### John Doe (person)
<img width="925" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/141332369-6f2b5bfb-91e6-4ce9-b3ff-78abf033e814.png">

---

#### Curtain Up Ltd (company)
<img width="669" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/141332373-17512eea-9754-4534-a275-ca17b7771fbe.png">

---

#### Conor Corge (person)
<img width="936" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/141332402-c4340d2d-aec5-4d2e-a54a-2accb0f2c096.png">

---

#### Stagecraft Ltd (company)
<img width="911" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/141332400-fd1d4b01-2074-4b59-8e21-b4c7fc994145.png">

---

#### Quincy Qux (person)
<img width="927" alt="quincy-qux-person" src="https://user-images.githubusercontent.com/10484515/141332395-32db56ee-7d73-4e7b-8253-04155cfd33e8.png">