### PR TITLE
Display award ceremony category nomination productions

### DIFF
--- a/src/components/Productions.jsx
+++ b/src/components/Productions.jsx
@@ -1,0 +1,35 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { AppendedVenue, InstanceLink } from '.';
+
+const Productions = props => {
+
+	const { productions } = props;
+
+	return (
+		<Fragment>
+
+			{
+				productions
+					.map((production, index) =>
+						<Fragment key={index}>
+
+							<InstanceLink instance={production} />
+
+							{
+								production.venue && (
+									<AppendedVenue venue={production.venue} />
+								)
+							}
+
+						</Fragment>
+					)
+					.reduce((prev, curr) => [prev, ', ', curr])
+			}
+
+		</Fragment>
+	);
+
+};
+
+export default Productions;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -30,6 +30,7 @@ import PrependedAward from './PrependedAward';
 import PrependedMembers from './PrependedMembers';
 import ProducerCredits from './ProducerCredits';
 import ProducerEntities from './ProducerEntities';
+import Productions from './Productions';
 import WritingCredits from './WritingCredits';
 import WritingEntities from './WritingEntities';
 
@@ -66,6 +67,7 @@ export {
 	PrependedMembers,
 	ProducerCredits,
 	ProducerEntities,
+	Productions,
 	WritingCredits,
 	WritingEntities
 };

--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, Entities, InstanceFacet, InstanceLink } from '../../components';
+import { App, Entities, InstanceFacet, InstanceLink, Productions } from '../../components';
 
 const AwardCeremony = props => {
 
@@ -41,7 +41,23 @@ const AwardCeremony = props => {
 															: (<span>{'Nomination: '}</span>)
 													}
 
-													<Entities entities={nomination.entities} />
+													{
+														nomination.entities.length > 0 && (
+															<Entities entities={nomination.entities} />
+														)
+													}
+
+													{
+														nomination.entities.length > 0 && nomination.productions.length > 0 && (
+															<Fragment>{' for '}</Fragment>
+														)
+													}
+
+													{
+														nomination.productions.length > 0 && (
+															<Productions productions={nomination.productions} />
+														)
+													}
 												</li>
 											)
 										}

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -1,6 +1,14 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, AppendedCoEntities, AppendedMembers, InstanceFacet, InstanceLink, List } from '../../components';
+import {
+	App,
+	AppendedCoEntities,
+	AppendedMembers,
+	InstanceFacet,
+	InstanceLink,
+	List,
+	Productions
+} from '../../components';
 
 const Company = props => {
 
@@ -136,6 +144,17 @@ const Company = props => {
 																							<AppendedCoEntities
 																								coEntities={nomination.coEntities}
 																							/>
+																						)
+																					}
+
+																					{
+																						nomination.productions.length > 0 && (
+																							<Fragment>
+																								<Fragment>{' for '}</Fragment>
+																								<Productions
+																									productions={nomination.productions}
+																								/>
+																							</Fragment>
 																						)
 																					}
 																				</Fragment>

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -1,6 +1,14 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, AppendedEmployerCompany, AppendedCoEntities, InstanceFacet, InstanceLink, List } from '../../components';
+import {
+	App,
+	AppendedEmployerCompany,
+	AppendedCoEntities,
+	InstanceFacet,
+	InstanceLink,
+	List,
+	Productions
+} from '../../components';
 
 const Person = props => {
 
@@ -147,6 +155,17 @@ const Person = props => {
 																							<AppendedCoEntities
 																								coEntities={nomination.coEntities}
 																							/>
+																						)
+																					}
+
+																					{
+																						nomination.productions.length > 0 && (
+																							<Fragment>
+																								<Fragment>{' for '}</Fragment>
+																								<Productions
+																									productions={nomination.productions}
+																								/>
+																							</Fragment>
 																						)
 																					}
 																				</Fragment>

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -1,13 +1,15 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import {
 	App,
 	AppendedFormatAndYear,
 	AppendedWritingCredits,
+	Entities,
 	InstanceFacet,
 	InstanceLink,
 	List,
-	ProducerCredits
+	ProducerCredits,
+	Productions
 } from '../../components';
 import { formatDate } from '../../lib/format-date';
 
@@ -25,7 +27,8 @@ const Production = props => {
 		producerCredits,
 		cast,
 		creativeCredits,
-		crewCredits
+		crewCredits,
+		awards
 	} = production;
 
 	const dateFormatOptions = { weekday: 'long', month: 'long' };
@@ -138,6 +141,81 @@ const Production = props => {
 					<InstanceFacet labelText='Crew'>
 
 						<List instances={crewCredits} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				awards?.length > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.ceremonies.map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.categories
+															.map((category, index) =>
+																<Fragment key={index}>
+																	{ category.name }{': '}
+
+																	{
+																		category.nominations
+																			.map((nomination, index) =>
+																				<Fragment key={index}>
+																					{
+																						nomination.isWinner
+																							? (<span>{'Winner'}</span>)
+																							: (<span>{'Nomination'}</span>)
+																					}
+
+																					{
+																						nomination.entities.length > 0 && (
+																							<Fragment>
+																								<Fragment>{': '}</Fragment>
+																								<Entities
+																									entities={nomination.entities}
+																								/>
+																							</Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.coProductions.length > 0 && (
+																							<Fragment>
+																								<Fragment>{' (with '}</Fragment>
+																								<Productions
+																									productions={nomination.coProductions}
+																								/>
+																								<Fragment>{')'}</Fragment>
+																							</Fragment>
+																						)
+																					}
+																				</Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</Fragment>
+							)
+						}
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Display award ceremony category nomination productions exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/458.

N.B. Several contrived productions/people/companies have been used for the purposes of demonstration.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="915" alt="laurence-olivier-awards-2020" src="https://user-images.githubusercontent.com/10484515/145675612-a667c78a-34b8-4c19-b918-5a2bfafa591a.png">

---

#### Laurence Olivier Awards 2019 (award ceremony)
<img width="749" alt="laurence-olivier-awards-2019" src="https://user-images.githubusercontent.com/10484515/145675791-0890cb38-8417-4e40-bbf6-37f4d0a2fcd8.png">

---

#### Laurence Olivier Awards 2018 (award ceremony)
<img width="890" alt="laurence-olivier-awards-2018" src="https://user-images.githubusercontent.com/10484515/145675789-2b25cf36-6ca0-4ff3-8607-f347733c4e40.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="814" alt="evening-standard-theatre-awards-2019" src="https://user-images.githubusercontent.com/10484515/145675788-95b8d711-0b8a-4b28-8a9a-38f54abb8490.png">

---

#### Evening Standard Theatre Awards 2018 (award ceremony)
<img width="725" alt="evening-standard-theatre-awards-2018" src="https://user-images.githubusercontent.com/10484515/145675787-e203dc75-9699-47e3-9016-39bf94a88a7d.png">

---

#### Evening Standard Theatre Awards 2017 (award ceremony)
<img width="922" alt="evening-standard-theatre-awards-2017" src="https://user-images.githubusercontent.com/10484515/145675786-16b260f7-d97a-42dd-86a8-d79b8ac13c0f.png">

---

#### Critics' Circle Theatre Awards 2019 (award ceremony)
<img width="909" alt="critics-circle-theatre-awards-2019" src="https://user-images.githubusercontent.com/10484515/145675784-d96bb634-d044-4897-aa8d-28d707131371.png">

---

#### John Doe (person)
<img width="930" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/145675633-bfb19f6c-9396-4fef-9e77-dfb1fbd852d9.png">

---

#### Curtain Up Ltd (company)
<img width="847" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/145675656-c770abb0-bff3-426e-b797-55af79869ad2.png">

---

#### Conor Corge (person)
<img width="939" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/145675673-2aee8db3-6e56-48f6-b89f-6bb637377861.png">

---

#### Stagecraft Ltd (company)
<img width="915" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/145675685-8f00e4bc-d177-4778-a19c-82f4224ab2f2.png">

---

#### Quincy Qux (person)
<img width="929" alt="quincy-qux-person" src="https://user-images.githubusercontent.com/10484515/145675748-1b250d23-0e6a-4346-b5e6-618239c21517.png">

---

#### Garply at Lyttelton Theatre (production)
<img width="919" alt="garply-lyttelton-production" src="https://user-images.githubusercontent.com/10484515/145675737-54b6aee4-69f3-428b-bed5-5fc110d0e5af.png">

---

#### Xyzzy at Playhouse Theatre (production)
<img width="928" alt="xyzzy-playhouse-production" src="https://user-images.githubusercontent.com/10484515/145675735-8daa3f98-6546-4278-9fc3-7ca8abae1191.png">