### PR TITLE
Display nomination customType

### DIFF
--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -36,9 +36,11 @@ const AwardCeremony = props => {
 											category.nominations.map((nomination, index) =>
 												<li key={index}>
 													{
-														nomination.isWinner
-															? (<span>{'Winner: '}</span>)
-															: (<span>{'Nomination: '}</span>)
+														nomination.customType
+															? (<span>{`${nomination.customType}: `}</span>)
+															: nomination.isWinner
+																? (<span>{'Winner: '}</span>)
+																: (<span>{'Nomination: '}</span>)
 													}
 
 													{

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -131,9 +131,11 @@ const Company = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -228,9 +230,11 @@ const Company = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -328,9 +332,11 @@ const Company = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -428,9 +434,11 @@ const Company = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -208,9 +208,11 @@ const Material = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -301,9 +303,11 @@ const Material = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -405,9 +409,11 @@ const Material = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -142,9 +142,11 @@ const Person = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -239,9 +241,11 @@ const Person = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -339,9 +343,11 @@ const Person = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{
@@ -439,9 +445,11 @@ const Person = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -174,9 +174,11 @@ const Production = props => {
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
 																					{
-																						nomination.isWinner
-																							? (<span>{'Winner'}</span>)
-																							: (<span>{'Nomination'}</span>)
+																						nomination.customType
+																							? (<span>{nomination.customType}</span>)
+																							: nomination.isWinner
+																								? (<span>{'Winner'}</span>)
+																								: (<span>{'Nomination'}</span>)
 																					}
 
 																					{


### PR DESCRIPTION
Display nomination customType exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/480.

N.B. Several contrived companies/materials/people/productions have been used for the purposes of demonstration.

---

#### Wordsmith Award 2008 (award ceremony)
<img width="887" alt="wordsmith-award-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/161835854-e0582fa8-bd94-4b3c-9e76-f574dda1cb8b.png">

---

#### Xyzzy at National Theatre: Olivier Theatre (production) - direct nominations
<img width="658" alt="xyzzy-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/161835870-f4ada7b2-30c3-41e3-90a4-dc3f46b57c8f.png">

---

#### Fred (material) - direct nominations
<img width="738" alt="fred-material" src="https://user-images.githubusercontent.com/10484515/161836057-5fbaac63-cedb-4774-8d0c-e4ed2f83547f.png">

---

#### John Doe (person) - direct nominations
<img width="861" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/161835893-2d0a473d-6318-402b-89bf-e135b81a6c72.png">

---

#### Playwrights Ltd (company) - direct nominations
<img width="863" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/161835912-aa92d67a-52fb-46b2-bad5-bb1086062a9a.png">

---

#### Plugh (original version) (material) - subsequent versions have nominations
<img width="859" alt="plugh-original-version-material" src="https://user-images.githubusercontent.com/10484515/161835922-6a858dd3-a236-491f-9cbb-72fadbec4e5a.png">

---

#### Francis Flob (person) - subsequent versions of their work have nominations
<img width="858" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/161835936-545414be-85f1-4129-8527-fcbd54f1b0ed.png">

---

#### Curtain Up Ltd (company) - subsequent versions of their work have nominations
<img width="854" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/161835959-89c09313-e740-4b29-9dbc-e4b7db497aed.png">

---

#### Waldo (material) - materials that used it as source material have nominations
<img width="935" alt="waldo-material" src="https://user-images.githubusercontent.com/10484515/161835970-18f913e0-c0da-4db3-9003-6ff18bec1efe.png">

---

#### Jane Roe (person) - materials that used their work as source material have nominations
<img width="938" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/161835984-876e591f-4439-42da-a0df-5aea70bde80a.png">

---

#### Fictioneers Ltd (company) - materials that used their work as source material have nominations
<img width="942" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/161836022-ec225155-b321-4955-ba77-35810087883e.png">

---

#### Talyse Tata (person) - materials to which they have granted rights have nominations
<img width="917" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/161837966-14e6f40f-8be5-4369-bbe8-3c875149584e.png">

----

#### Cinerights Ltd (company) - materials to which they have granted rights have nominations
<img width="913" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/161837994-a0c44d77-79cc-4dc9-8580-6fe0a9cdfee7.png">