### PR TITLE
Replace nomination customType with type

### DIFF
--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -35,13 +35,7 @@ const AwardCeremony = props => {
 										{
 											category.nominations.map((nomination, index) =>
 												<li key={index}>
-													{
-														nomination.customType
-															? (<span>{`${nomination.customType}: `}</span>)
-															: nomination.isWinner
-																? (<span>{'Winner: '}</span>)
-																: (<span>{'Nomination: '}</span>)
-													}
+													<span>{`${nomination.type}: `}</span>
 
 													{
 														nomination.entities.length > 0 && (

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -130,13 +130,7 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.members?.length > 0 && (
@@ -229,13 +223,7 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -331,13 +319,7 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (
@@ -433,13 +415,7 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.rightsGrantorMaterials.length > 0 && (

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -207,13 +207,7 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.entities.length > 0 && (
@@ -302,13 +296,7 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -408,13 +396,7 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -141,13 +141,7 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.employerCompany && (
@@ -240,13 +234,7 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -342,13 +330,7 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (
@@ -444,13 +426,7 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.rightsGrantorMaterials.length > 0 && (

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -173,13 +173,7 @@ const Production = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					{
-																						nomination.customType
-																							? (<span>{nomination.customType}</span>)
-																							: nomination.isWinner
-																								? (<span>{'Winner'}</span>)
-																								: (<span>{'Nomination'}</span>)
-																					}
+																					<span>{nomination.type}</span>
 
 																					{
 																						nomination.entities.length > 0 && (


### PR DESCRIPTION
Replace nomination `customType` property with `type` as exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/481.

The API change allows this app to passively display the `type` value rather than have to calculate the value to display itself.