### PR TITLE
Style nomination winners in bold

### DIFF
--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -8,3 +8,7 @@
 .role-text {
 	font-style: italic;
 }
+
+.nomination-winner-text {
+	font-weight: bold;
+}

--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -35,7 +35,9 @@ const AwardCeremony = props => {
 										{
 											category.nominations.map((nomination, index) =>
 												<li key={index}>
-													<span>{`${nomination.type}: `}</span>
+													<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+														{`${nomination.type}: `}
+													</span>
 
 													{
 														nomination.entities.length > 0 && (

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -130,7 +130,9 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.members?.length > 0 && (
@@ -223,7 +225,9 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -319,7 +323,9 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (
@@ -415,7 +421,9 @@ const Company = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.rightsGrantorMaterials.length > 0 && (

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -207,7 +207,9 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.entities.length > 0 && (
@@ -296,7 +298,9 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -396,7 +400,9 @@ const Material = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -141,7 +141,9 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.employerCompany && (
@@ -234,7 +236,9 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.subsequentVersionMaterials.length > 0 && (
@@ -330,7 +334,9 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.sourcingMaterials.length > 0 && (
@@ -426,7 +432,9 @@ const Person = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.rightsGrantorMaterials.length > 0 && (

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -173,7 +173,9 @@ const Production = props => {
 																		category.nominations
 																			.map((nomination, index) =>
 																				<Fragment key={index}>
-																					<span>{nomination.type}</span>
+																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																						{nomination.type}
+																					</span>
 
 																					{
 																						nomination.entities.length > 0 && (


### PR DESCRIPTION
This PR applies styling to the text that describes the nomination type when the nomination was the winner in its category.

---

#### Laurence Olivier Awards 2008 (award ceremony)
<img width="946" alt="laurence-olivier-awards-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/162067517-6c5ca7f5-c952-4dfa-8c08-9475452e7822.png">

---

#### Macbeth at Gielgud Theatre (production)
<img width="553" alt="macbeth-gielgud-theatre-production" src="https://user-images.githubusercontent.com/10484515/162067542-6242e2f7-0d86-42c3-8650-e010db84d183.png">

---

#### Black Watch (material)
<img width="545" alt="black-watch-material" src="https://user-images.githubusercontent.com/10484515/162067564-c22586cc-5788-4222-b597-2b67505bb128.png">

---

#### Patrick Stewart (person)
<img width="468" alt="patrick-stewart-person" src="https://user-images.githubusercontent.com/10484515/162067583-62688311-12f6-4a9b-a659-f7015e3106bb.png">

---

#### Théâtre de Complicité (company)
<img width="845" alt="théâtre-de-complicité-company" src="https://user-images.githubusercontent.com/10484515/162067594-8c3286a6-999b-4c66-ab1b-ce7026bb40fb.png">