### PR TITLE
Display material sub-materials

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -13,7 +13,8 @@ import {
 	AppendedVenue,
 	AppendedWritingCredits,
 	InstanceLink,
-	PrependedAward
+	PrependedAward,
+	PrependedSurMaterial
 } from '.';
 
 const List = props => {
@@ -30,6 +31,12 @@ const List = props => {
 						{
 							instance.award && (
 								<PrependedAward award={instance.award} />
+							)
+						}
+
+						{
+							instance.surMaterial && (
+								<PrependedSurMaterial surMaterial={instance.surMaterial} />
 							)
 						}
 

--- a/src/components/Materials.jsx
+++ b/src/components/Materials.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink } from '.';
+import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink, PrependedSurMaterial } from '.';
 
 const Materials = props => {
 
@@ -13,6 +13,12 @@ const Materials = props => {
 				materials
 					.map((material, index) =>
 						<Fragment key={index}>
+
+							{
+								material.surMaterial && (
+									<PrependedSurMaterial surMaterial={material.surMaterial} />
+								)
+							}
 
 							<InstanceLink instance={material} />
 

--- a/src/components/PrependedSurMaterial.jsx
+++ b/src/components/PrependedSurMaterial.jsx
@@ -1,0 +1,21 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { InstanceLink } from '.';
+
+const PrependedSurMaterial = props => {
+
+	const { surMaterial } = props;
+
+	return (
+		<Fragment>
+
+			<InstanceLink instance={surMaterial} />
+
+			<Fragment>{': '}</Fragment>
+
+		</Fragment>
+	);
+
+};
+
+export default PrependedSurMaterial;

--- a/src/components/WritingEntities.jsx
+++ b/src/components/WritingEntities.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { AppendedFormatAndYear, InstanceLink, WritingCredits } from '.';
+import { AppendedFormatAndYear, InstanceLink, PrependedSurMaterial, WritingCredits } from '.';
 
 const WritingEntities = props => {
 
@@ -13,6 +13,12 @@ const WritingEntities = props => {
 				entities
 					.map((entity, index) =>
 						<Fragment key={index}>
+
+							{
+								entity.surMaterial && (
+									<PrependedSurMaterial surMaterial={entity.surMaterial} />
+								)
+							}
 
 							{
 								entity.uuid

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,6 +29,7 @@ import Navigation from './Navigation';
 import PageTitle from './PageTitle';
 import PrependedAward from './PrependedAward';
 import PrependedMembers from './PrependedMembers';
+import PrependedSurMaterial from './PrependedSurMaterial';
 import ProducerCredits from './ProducerCredits';
 import ProducerEntities from './ProducerEntities';
 import Productions from './Productions';
@@ -67,6 +68,7 @@ export {
 	PageTitle,
 	PrependedAward,
 	PrependedMembers,
+	PrependedSurMaterial,
 	ProducerCredits,
 	ProducerEntities,
 	Productions,

--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -12,6 +12,10 @@ export default instance => {
 			if (instance.award) title = `${instance.award.name} ${title}`;
 			return title;
 
+		case MODELS.MATERIAL:
+			if (instance.surMaterial) title = `${instance.surMaterial.name}: ${title}`;
+			return title;
+
 		case MODELS.VENUE:
 			if (instance.surVenue) title = `${instance.surVenue.name}: ${title}`;
 			return title;

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -23,6 +23,8 @@ const Material = props => {
 		format,
 		year,
 		writingCredits,
+		surMaterial,
+		subMaterials,
 		characterGroups,
 		originalVersionMaterial,
 		subsequentVersionMaterials,
@@ -65,6 +67,41 @@ const Material = props => {
 					<InstanceFacet labelText='Writers'>
 
 						<WritingCredits credits={writingCredits} isAppendage={false} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				surMaterial && (
+					<InstanceFacet labelText='Part of'>
+
+						<InstanceLink instance={surMaterial} />
+
+						{
+							(surMaterial.format || surMaterial.year) && (
+								<AppendedFormatAndYear
+									format={surMaterial.format}
+									year={surMaterial.year}
+								/>
+							)
+						}
+
+						{
+							surMaterial.writingCredits?.length > 0 && (
+								<AppendedWritingCredits credits={surMaterial.writingCredits} />
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subMaterials?.length > 0 && (
+					<InstanceFacet labelText='Comprises'>
+
+						<List instances={subMaterials} />
 
 					</InstanceFacet>
 				)
@@ -235,6 +272,31 @@ const Material = props => {
 
 																					{
 																						nomination.productions.length > 0 &&
+																						(nomination.recipientMaterial || nomination.coMaterials.length > 0) && (
+																							<Fragment>{';'}</Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.recipientMaterial && (
+																							<Fragment>
+																								<Fragment>{' (for '}</Fragment>
+																								<InstanceLink instance={nomination.recipientMaterial} />
+																								{
+																									(nomination.recipientMaterial.format || nomination.recipientMaterial.year) && (
+																										<AppendedFormatAndYear
+																											format={nomination.recipientMaterial.format}
+																											year={nomination.recipientMaterial.year}
+																										/>
+																									)
+																								}
+																								<Fragment>{')'}</Fragment>
+																							</Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.recipientMaterial &&
 																						nomination.coMaterials.length > 0 && (
 																							<Fragment>{';'}</Fragment>
 																						)

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -9,6 +9,7 @@ import {
 	InstanceLink,
 	List,
 	Materials,
+	PrependedSurMaterial,
 	ProducerCredits,
 	Productions
 } from '../../components';
@@ -41,13 +42,19 @@ const Production = props => {
 				material && (
 					<InstanceFacet labelText='Material'>
 
+						{
+							material.surMaterial && (
+								<PrependedSurMaterial surMaterial={material.surMaterial} />
+							)
+						}
+
 						<InstanceLink instance={material} />
 
-							{
-								(material.format || material.year) && (
-									<AppendedFormatAndYear format={material.format} year={material.year} />
-								)
-							}
+						{
+							(material.format || material.year) && (
+								<AppendedFormatAndYear format={material.format} year={material.year} />
+							)
+						}
 
 						{
 							material.writingCredits?.length > 0 && (


### PR DESCRIPTION
Display material sub-materials exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/485.

N.B. Several contrived companies/materials/people/productions have been used for the purposes of demonstration.

### References:
- [The Guardian: Triple threat: the trouble with theatrical trilogies](https://www.theguardian.com/stage/2014/oct/03/triple-threat-theatrical-trilogies)

---

## Real-life examples

#### The Coast of Utopia (trilogy of plays) (material)
<img width="349" alt="the-coast-of-utopia-material" src="https://user-images.githubusercontent.com/10484515/178113324-05627d8a-c3e1-46c6-98ea-6fd9e4809aa1.png">

---

#### Voyage (play) (material)
<img width="499" alt="the-coast-of-utopia-voyage-material" src="https://user-images.githubusercontent.com/10484515/178113358-cfcaf3b7-7c48-4e10-b3da-fe6bec2ec3a1.png">

---

#### Tom Stoppard (person)
<img width="431" alt="tom-stoppard-person" src="https://user-images.githubusercontent.com/10484515/178113371-5d01490b-933b-454b-b02a-af59f5b4698d.png">

---

#### Michael Bakunin (character)
<img width="419" alt="michael-bakunin-character" src="https://user-images.githubusercontent.com/10484515/178113403-bc233573-058a-4499-b6df-886636186312.png">

---

#### Voyage at Olivier Theatre (production)
<img width="385" alt="the-coast-of-utopia-voyage-olivier-production" src="https://user-images.githubusercontent.com/10484515/178113439-703076d3-7e69-4a69-aaa7-3938bada1807.png">

---

#### Materials list
<img width="877" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/178114447-3c76c980-4ede-4879-90b4-367733bcd2b9.png">

---

## Test examples

### `award-ceremonies-nominated-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="931" alt="wordsmith-award-2010-award-ceremomy" src="https://user-images.githubusercontent.com/10484515/224774413-4cdb947c-666f-4480-bd41-2ad26c875afc.png">

---

#### Playwriting Prize 2009 (award ceremony)
<img width="925" alt="playwriting-prize-2009-award-ceremony" src="https://user-images.githubusercontent.com/10484515/178113539-f620b89e-5920-4ed7-9868-824d10aa6916.png">

---

#### John Doe (person): credit for directly nominated material
<img width="927" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/224774433-bc9ec880-2822-4eba-bff4-9fa57af09d41.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="922" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/224774443-b820dd2d-551c-4b33-9018-944b8000ce66.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
N.B. Nominations/awards for its sur-material are now captured via association
<img width="914" alt="sub-plugh-material" src="https://user-images.githubusercontent.com/10484515/224774456-e2497bcf-ce4c-4ddb-b5ec-2e505e1c02a6.png">

---

#### Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations
N.B. Nominations/awards for its sub-materials are now captured via association
<img width="921" alt="sur-plugh-material" src="https://user-images.githubusercontent.com/10484515/224774465-c340e9de-f6fc-4ec5-819a-05809c4a70be.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="910" alt="francis-flob-material" src="https://user-images.githubusercontent.com/10484515/224774479-a62567ee-396c-4884-9b01-8a34cbadcfcc.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="908" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/224774488-fd52d292-aeec-4142-b434-cfe550b601ae.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
N.B. Nominations/awards for its sur-material are now captured via association
<img width="941" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/224774507-f7bfed78-fa28-41bd-a278-4b1c73c5d2d0.png">

---

#### Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations
N.B. Nominations/awards for its sub-materials are now captured via association
<img width="947" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/224774517-cffe5e5b-5af1-44a8-9eb5-7aa5bb676e65.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="938" alt="jane-roe-material" src="https://user-images.githubusercontent.com/10484515/224774528-8a52d101-d829-4602-b734-b66c2859a153.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="947" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/224774540-ad06e37c-0dc2-4226-95e4-82d5d372d5fb.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="932" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/224774555-f5e31909-6e5e-479c-8fc9-96babbbe2e0e.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="937" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/224774565-33320322-1ae2-401e-b1ac-acb8e185e93f.png">

---

### `award-ceremonies-with-sub-materials.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="916" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/224778251-7cbe0f68-c81d-4079-ba31-f56055454017.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="920" alt="evening-standard-theatre-awards-2019" src="https://user-images.githubusercontent.com/10484515/178113792-cbd8ab68-6bd5-414a-a7b9-dd55d4ffc6a0.png">

---

#### Conor Corge (person)
<img width="926" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/224778303-f9770026-d7b7-4b35-a7fe-4b24e40fd05d.png">

---

#### Stagecraft Ltd (company)
<img width="923" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/224778323-867fccee-e1b5-44c1-a8c8-840c1249e78a.png">

---

#### Ferdinand Foo (person)
<img width="931" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/224778359-7073f340-ae6f-4a02-afe3-534c765bb138.png">

---

#### Sub-Wibble at Old Vic Theatre (production)
<img width="820" alt="sub-wibble-at-old-vic-production" src="https://user-images.githubusercontent.com/10484515/224778422-723b955b-9ea3-42c1-81e3-34d605269a44.png">

---

#### Sur-Wibble at Old Vic Theatre (production)
<img width="748" alt="sur-wibble-old-vic-production" src="https://user-images.githubusercontent.com/10484515/178113847-9c067e62-8598-49cc-b71f-77b2ea4f102b.png">

---

#### Sub-Wibble (play) (material)
N.B. Nominations/awards for its sur-material are now captured via association
<img width="905" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/224778504-4ba7b740-ba90-4ec2-b07c-98b65dfc1a69.png">

---

#### Sur-Wibble (trilogy of plays) (material)
N.B. Nominations/awards for its sub-materials are now captured via association
<img width="918" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/224778552-9157374d-e8e2-47f0-b927-7bc8b3465dc5.png">

---

### `material-with-multi-sub-material-versions.test.js`

#### Agamemnon (original version) (material)
<img width="607" alt="agamemnon-original-version-material" src="https://user-images.githubusercontent.com/10484515/224782254-21976f56-1a81-4b1b-ae4b-39c069322a0f.png">

---

#### Agamemnon (subsequent version) (material)
<img width="789" alt="agamemnon-subsequent-version-material" src="https://user-images.githubusercontent.com/10484515/224782268-198cbfa4-86c3-434a-b734-84cb27c22c22.png">

---

#### Aeschylus (person)
<img width="812" alt="aeschylus-person" src="https://user-images.githubusercontent.com/10484515/224782281-ec70999e-ed88-48cb-8cfb-5f258231e9ff.png">

---

#### The Fathers of Tragedy (company)
<img width="813" alt="the-fathers-of-tragedy-company" src="https://user-images.githubusercontent.com/10484515/224782286-dcd02ee8-64ed-4530-ae8b-747e351eeb02.png">

---

### `material-with-source-sub-material.test.js`

#### Bring Up the Bodies (novel) (material)
<img width="916" alt="bring-up-the-bodies-novel-material" src="https://user-images.githubusercontent.com/10484515/224784697-80efd838-f9b7-49ec-9d4b-bf32d4a346ec.png">

---

#### Bring Up the Bodies (play) (material)
<img width="928" alt="bring-up-the-bodies-play-material" src="https://user-images.githubusercontent.com/10484515/224784722-6e002cfe-18ea-4240-abd5-a9e443abab60.png">

---

#### Hilary Mantel (person)
<img width="924" alt="hilary-mantel-person" src="https://user-images.githubusercontent.com/10484515/224784733-28e84673-fe4b-401b-8c7d-c8cc987c581d.png">

---

#### Mike Poulton (person)
<img width="926" alt="mike-poulton-person" src="https://user-images.githubusercontent.com/10484515/224784744-835b6dc9-001e-43f0-8cce-81bbb231fa60.png">

---

#### The Mantel Group (company)
<img width="919" alt="the-mantel-group-company" src="https://user-images.githubusercontent.com/10484515/224784765-0333c1b3-382a-4866-8382-8ffa0a1cc5fb.png">

---

#### Royal Shakespeare Company (company)
<img width="926" alt="royal-shakespeare-company" src="https://user-images.githubusercontent.com/10484515/224784780-d9f348ab-ba0e-4729-80be-a485745bec64.png">

---

#### Bring Up the Bodies at Swan Theatre (production)
<img width="923" alt="bring-up-the-bodies-at-swan-theatre-production" src="https://user-images.githubusercontent.com/10484515/224784785-d2c62546-3ebb-4e84-ac2f-632b44b7df9b.png">

---

#### Thomas Cromwell (character)
<img width="920" alt="thomas-cromwell-character" src="https://user-images.githubusercontent.com/10484515/224784803-e5257c6f-517d-46ad-b4b6-4cba886f58b0.png">

---

#### Materials list
<img width="942" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/224784859-1bef8c86-6d8b-405b-9d5f-3369eae573bc.png">

---

### `material-with-sub-materials.test.js`

#### The Coast of Utopia (material with sub-materials)
<img width="460" alt="the-coast-of-utopia-material" src="https://user-images.githubusercontent.com/10484515/224789482-3eee0ff9-449d-45fe-ab11-1360cedc623e.png">

---

#### Voyage (material with sur-material)
<img width="544" alt="voyage-material" src="https://user-images.githubusercontent.com/10484515/224789504-a0912025-666c-4b8b-8400-83cf6e0ca407.png">

---

#### Alexander Herzen (character)
<img width="559" alt="alexander-herzen-character" src="https://user-images.githubusercontent.com/10484515/224789523-4b56e3b4-d902-472c-a3c4-81c634d37584.png">

---

#### Ivan Turgenev (character)
<img width="552" alt="ivan-turgenev-character" src="https://user-images.githubusercontent.com/10484515/224789552-c134a0a2-fc13-4c34-89c8-eac247f4d67f.png">

---

#### Voyage at Olivier Theatre (production)
<img width="517" alt="voyage-at-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/224789570-0ef72707-ace6-4404-a165-f8d476e2d730.png">

---

#### The Coast of Utopia at Olivier Theatre (production)
<img width="520" alt="the-coats-of-utopia-olivier-production" src="https://user-images.githubusercontent.com/10484515/178114271-7cb428ca-2004-41db-bdaf-e532a9f5dbed.png">

---

#### Tom Stoppard (person)
<img width="559" alt="tom-stoppard-person" src="https://user-images.githubusercontent.com/10484515/224789667-b7b6c075-313b-4b1e-b131-01ad546e5b34.png">

---

#### The Sträussler Group (company)
<img width="557" alt="the-sträussler-group-company" src="https://user-images.githubusercontent.com/10484515/224789685-f8111237-8cde-486c-b057-f9928fd16e27.png">

---

#### Materials list
<img width="551" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/224789693-c1b67eeb-6d28-4f99-8952-2e0a3d421f03.png">

---

### `sub-material-with-rights-grantor.test.js`

#### C S Lewis Society (company)
<img width="927" alt="c-s-lewis-society-company" src="https://user-images.githubusercontent.com/10484515/224790447-0e007884-c2e3-4dfb-b58d-f137e22a75d6.png">

---

#### Sarah Selden (person)
<img width="919" alt="sarah-snelden-person" src="https://user-images.githubusercontent.com/10484515/224790469-8a0364a4-48cf-407e-a00e-292b1a47222d.png">