### PR TITLE
Use Volta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Server-side rendered (SSR) application that provides listings for theatrical pro
 
 ## Setup
 - Clone this repo.
-- Set Node to version specified in `.nvmrc`, which can be achieved by running `$ nvm use`.
+- Set Node to version specified in `.nvmrc`, which can be achieved by running `$ nvm use` (if using [Volta](https://docs.volta.sh/guide/getting-started) then it will be set automatically).
 - Install node modules: `$ npm install`.
 - Compile code: `$ npm run build`.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
   ],
   "engines": {
     "node": "18.7.0",
-    "npm": "8.17.1"
+    "npm": "8.17.0"
+  },
+  "volta": {
+    "node": "18.7.0",
+    "npm": "8.17.0"
   },
   "dependencies": {
     "express": "^4.14.0",


### PR DESCRIPTION
This PR adds a `volta` property to the `package.json` file so that the Node.js version will automatically be set to the specified version  when developing locally, thereby removing the need to run `$ nvm use` manually, which can easily be forgotten and cause issues if developing on multiple repos that run on different Node.js versions.

### References:
- [Volta: Getting Started](https://docs.volta.sh/guide/getting-started)
- [Volta: Understanding Volta](https://docs.volta.sh/guide/understanding)