### PR TITLE
Display character variant named depictions + portrayals without JoinedRoles component

### DIFF
--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -7,7 +7,7 @@
 	color: color-variables.$theme-color;
 }
 
-.role-text {
+.fictional-name-text {
 	font-style: italic;
 }
 

--- a/src/components/AppendedDepictions.jsx
+++ b/src/components/AppendedDepictions.jsx
@@ -14,7 +14,9 @@ const AppendedDepictions = props => {
 
 							{
 								depiction.displayName && (
-									<Fragment>{' (as '}<span className="role-text">{ depiction.displayName }</span>)</Fragment>
+									<Fragment>
+										{' (as '}<span className="fictional-name-text">{ depiction.displayName }</span>)
+									</Fragment>
 								)
 							}
 

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -20,7 +20,7 @@ const AppendedPerformers = props => {
 
 							<Fragment>{' … '}</Fragment>
 
-							<span className="role-text">
+							<span className="fictional-name-text">
 
 								{
 									performer.roleName

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -7,7 +7,7 @@ const JoinedRoles = props => {
 	const { instances } = props;
 
 	return (
-		<span className="role-text">
+		<span className="fictional-name-text">
 
 			{
 				instances
@@ -17,7 +17,7 @@ const JoinedRoles = props => {
 							{
 								instance.uuid
 									? <InstanceLink instance={instance} />
-									: instance.name || instance
+									: instance.name
 							}
 
 							{

--- a/src/pages/instances/Character.jsx
+++ b/src/pages/instances/Character.jsx
@@ -1,6 +1,6 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, JoinedRoles, List } from '../../components';
+import { App, InstanceFacet, List } from '../../components';
 
 const Character = props => {
 
@@ -15,7 +15,11 @@ const Character = props => {
 				variantNamedDepictions?.length > 0 && (
 					<InstanceFacet labelText='Variant named depictions'>
 
-						<JoinedRoles instances={variantNamedDepictions} />
+						<span className="fictional-name-text">
+
+							{ variantNamedDepictions.join(' / ') }
+
+						</span>
 
 					</InstanceFacet>
 				)
@@ -35,7 +39,11 @@ const Character = props => {
 				variantNamedPortrayals?.length > 0 && (
 					<InstanceFacet labelText='Variant named portrayals'>
 
-						<JoinedRoles instances={variantNamedPortrayals} />
+						<span className="fictional-name-text">
+
+							{ variantNamedPortrayals.join(' / ') }
+
+						</span>
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Character `variantNamedDepictions` and `variantNamedPortrayals` are arrays of strings, so by using the JoinedRoles component to render them we require it to be that much more complex to accommodate this type as well as the arrays of objects that it otherwise receives as arguments.

This PR renders the `variantNamedDepictions` and `variantNamedPortrayals` directly in the Character instance page component, allowing the JoinedRoles component to become that much simpler.

It also renames the `role-text` class to `fictional-name-text` given the values of `variantNamedDepictions` fall outside of this definition. N.B. This styling (italicised text) is currently only intended to be applied when a fictional name is in and amongst real-world names, e.g. a real-world actor (non-italicised) presented next to the names of the fictional roles they played (italicised); however, a list of fictional characters on the material page is not mixed with any real-world names and so would not be italicised.