### PR TITLE
Replace node-fetch with Node.js native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "express": "4.18.1",
     "express-session": "1.17.3",
     "morgan": "1.10.0",
-    "node-fetch": "2.6.6",
     "preact": "10.11.0",
     "preact-render-to-string": "5.2.4",
     "serve-favicon": "2.5.0",

--- a/src/lib/fetch-from-api.js
+++ b/src/lib/fetch-from-api.js
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 const API_URL_BASE = 'http://localhost:3000';
 
 export default async apiPath => {


### PR DESCRIPTION
### References:
- [Node.js v18.12.0 documentation: Global objects - fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)
  - > Stability: 1 - Experimental (The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments.). Disable this API with the `--no-experimental-fetch` CLI flag.
  - > A browser-compatible implementation of the `fetch()` function.
- [DEV Community: The NodeJS 18 Fetch API](https://dev.to/andrewbaisden/the-nodejs-18-fetch-api-72m)