### PR TITLE
Display production sub-productions

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -14,7 +14,7 @@ import {
 	AppendedWritingCredits,
 	InstanceLink,
 	PrependedAward,
-	PrependedSurMaterial
+	PrependedSurInstance
 } from '.';
 
 const List = props => {
@@ -36,7 +36,13 @@ const List = props => {
 
 						{
 							instance.surMaterial && (
-								<PrependedSurMaterial surMaterial={instance.surMaterial} />
+								<PrependedSurInstance surInstance={instance.surMaterial} />
+							)
+						}
+
+						{
+							instance.surProduction && (
+								<PrependedSurInstance surInstance={instance.surProduction} />
 							)
 						}
 

--- a/src/components/Materials.jsx
+++ b/src/components/Materials.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink, PrependedSurMaterial } from '.';
+import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink, PrependedSurInstance } from '.';
 
 const Materials = props => {
 
@@ -16,7 +16,7 @@ const Materials = props => {
 
 							{
 								material.surMaterial && (
-									<PrependedSurMaterial surMaterial={material.surMaterial} />
+									<PrependedSurInstance surInstance={material.surMaterial} />
 								)
 							}
 

--- a/src/components/PrependedSurInstance.jsx
+++ b/src/components/PrependedSurInstance.jsx
@@ -2,14 +2,14 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import { InstanceLink } from '.';
 
-const PrependedSurMaterial = props => {
+const PrependedSurInstance = props => {
 
-	const { surMaterial } = props;
+	const { surInstance } = props;
 
 	return (
 		<Fragment>
 
-			<InstanceLink instance={surMaterial} />
+			<InstanceLink instance={surInstance} />
 
 			<Fragment>{': '}</Fragment>
 
@@ -18,4 +18,4 @@ const PrependedSurMaterial = props => {
 
 };
 
-export default PrependedSurMaterial;
+export default PrependedSurInstance;

--- a/src/components/Productions.jsx
+++ b/src/components/Productions.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { AppendedVenue, InstanceLink } from '.';
+import { AppendedVenue, InstanceLink, PrependedSurInstance } from '.';
 
 const Productions = props => {
 
@@ -13,6 +13,12 @@ const Productions = props => {
 				productions
 					.map((production, index) =>
 						<Fragment key={index}>
+
+							{
+								production.surProduction && (
+									<PrependedSurInstance surInstance={production.surProduction} />
+								)
+							}
 
 							<InstanceLink instance={production} />
 

--- a/src/components/WritingEntities.jsx
+++ b/src/components/WritingEntities.jsx
@@ -1,6 +1,6 @@
 import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { AppendedFormatAndYear, InstanceLink, PrependedSurMaterial, WritingCredits } from '.';
+import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from '.';
 
 const WritingEntities = props => {
 
@@ -16,7 +16,7 @@ const WritingEntities = props => {
 
 							{
 								entity.surMaterial && (
-									<PrependedSurMaterial surMaterial={entity.surMaterial} />
+									<PrependedSurInstance surInstance={entity.surMaterial} />
 								)
 							}
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,7 +29,7 @@ import Navigation from './Navigation';
 import PageTitle from './PageTitle';
 import PrependedAward from './PrependedAward';
 import PrependedMembers from './PrependedMembers';
-import PrependedSurMaterial from './PrependedSurMaterial';
+import PrependedSurInstance from './PrependedSurInstance';
 import ProducerCredits from './ProducerCredits';
 import ProducerEntities from './ProducerEntities';
 import Productions from './Productions';
@@ -68,7 +68,7 @@ export {
 	PageTitle,
 	PrependedAward,
 	PrependedMembers,
-	PrependedSurMaterial,
+	PrependedSurInstance,
 	ProducerCredits,
 	ProducerEntities,
 	Productions,

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -3,13 +3,15 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 import {
 	App,
 	AppendedFormatAndYear,
+	AppendedProductionDates,
+	AppendedVenue,
 	AppendedWritingCredits,
 	Entities,
 	InstanceFacet,
 	InstanceLink,
 	List,
 	Materials,
-	PrependedSurMaterial,
+	PrependedSurInstance,
 	ProducerCredits,
 	Productions
 } from '../../components';
@@ -26,6 +28,8 @@ const Production = props => {
 		pressDate,
 		endDate,
 		venue,
+		surProduction,
+		subProductions,
 		producerCredits,
 		cast,
 		creativeCredits,
@@ -44,7 +48,7 @@ const Production = props => {
 
 						{
 							material.surMaterial && (
-								<PrependedSurMaterial surMaterial={material.surMaterial} />
+								<PrependedSurInstance surInstance={material.surMaterial} />
 							)
 						}
 
@@ -109,6 +113,41 @@ const Production = props => {
 						}
 
 						<InstanceLink instance={venue} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				surProduction && (
+					<InstanceFacet labelText='Part of'>
+
+						<InstanceLink instance={surProduction} />
+
+						{
+							surProduction.venue && (
+								<AppendedVenue venue={surProduction.venue} />
+							)
+						}
+
+						{
+							(surProduction.startDate || surProduction.endDate) && (
+								<AppendedProductionDates
+									startDate={surProduction.startDate}
+									endDate={surProduction.endDate}
+								/>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subProductions?.length > 0 && (
+					<InstanceFacet labelText='Comprises'>
+
+						<List instances={subProductions} />
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
Display production sub-productions exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/503.

N.B. Several contrived companies/materials/people/productions have been used for the purposes of demonstration.

### References:
- [The Guardian: Triple threat: the trouble with theatrical trilogies](https://www.theguardian.com/stage/2014/oct/03/triple-threat-theatrical-trilogies)

---

## Real-life examples

#### The Coast of Utopia at Olivier Theatre (production)
<img width="500" alt="01-the-coast-of-utopia-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/208251975-7363b2c5-661f-488a-863c-7f9e2167c5a3.png">

---

#### Voyage at Olivier Theatre (production)
<img width="536" alt="02-voyage-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/208251978-4ce40008-a4e8-416a-a13d-30a5957ea16f.png">

---

#### Voyage (material)
<img width="618" alt="03-voyage-material" src="https://user-images.githubusercontent.com/10484515/208251979-541e0756-7a18-4749-84b1-91cd3e3af5c1.png">

---

#### Olivier Theatre (venue)
<img width="545" alt="04-olivier-theatre-venue" src="https://user-images.githubusercontent.com/10484515/208251980-97157c0d-7652-4acb-a11d-205796ab5b8e.png">

---

#### National Theatre Company (company)
<img width="876" alt="05-national-theatre-company" src="https://user-images.githubusercontent.com/10484515/208251981-dcd13034-66f5-49ce-9951-62aea7d3468e.png">

---

#### Alexander Herzen (character)
<img width="927" alt="06-alexander-herzen-character" src="https://user-images.githubusercontent.com/10484515/208251982-6f1f0f18-ebf0-4cc8-8100-cb0e4c405ccc.png">

---

#### Stephen Dillane (person)
<img width="746" alt="07-stephen-dillane-person" src="https://user-images.githubusercontent.com/10484515/208251983-dcd0f28d-b8b4-4bdc-b170-420e91fb5472.png">

---

#### Trevor Nunn (person)
<img width="688" alt="08-trevor-nunn-person" src="https://user-images.githubusercontent.com/10484515/208251984-c92659e7-3ea7-42bd-8327-476dc5ac997c.png">

---

#### Productions list
<img width="614" alt="09-productions-list" src="https://user-images.githubusercontent.com/10484515/208251986-c7180642-7089-4a6a-bfd3-75bd7b4c97e6.png">

---

## Test examples

### `award-ceremonies-with-crediting-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="938" alt="01-wordsmith-award-2010-awards-ceremony" src="https://user-images.githubusercontent.com/10484515/208252060-b66300b0-c94e-4825-9f9f-71156413a57e.png">

---

#### John Doe (person): credit for directly nominated material
<img width="929" alt="02-john-doe-person" src="https://user-images.githubusercontent.com/10484515/208252061-66c0b332-e087-49e8-a307-473fb487d997.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="932" alt="03-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252062-035a3193-5015-4f58-b6aa-2f8c531b44d2.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="945" alt="04-sub-plugh-material" src="https://user-images.githubusercontent.com/10484515/208252063-9ffbc532-232f-480e-a1bd-963177a45c20.png">

---

#### Sur-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="947" alt="05-sur-plugh-material" src="https://user-images.githubusercontent.com/10484515/208252064-cbb682b3-9349-45cf-aee5-c544b46e1968.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="944" alt="06-francis-flob-person" src="https://user-images.githubusercontent.com/10484515/208252067-67e904ae-e6f5-4a6b-96d5-30418aaa01e1.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="942" alt="07-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252071-05a28b05-7d24-48ca-b06f-245b3204bd34.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
<img width="934" alt="08-sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/208252073-610c6977-0246-4444-befc-1600633b107f.png">

---

#### Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="934" alt="09-sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/208252076-17d524b2-3241-4091-ab8c-c560b1120095.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="938" alt="10-jane-roe-person" src="https://user-images.githubusercontent.com/10484515/208252077-2eaa4428-e6c0-498f-aa37-1a05c6ead729.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="943" alt="11-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252079-7bacd72b-ee87-4db9-8467-6eb330c332e9.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="934" alt="12-talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/208252080-f771cb70-9ad3-4b6f-8a59-b27712400086.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="940" alt="13-cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252081-2f3d9b59-8dfd-42a3-a692-83a9c0eb4ef5.png">

---

### `award-ceremonies-with-sub-materials-sub-prods.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="925" alt="01-laurence-olivier-awards-2020-awards-ceremony" src="https://user-images.githubusercontent.com/10484515/208252243-8d91d470-a546-437e-b92b-94a3ad28a5e5.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="921" alt="02-evening-standard-theatre-awards-2019-awards-ceremony" src="https://user-images.githubusercontent.com/10484515/208252244-da51d9c9-583d-4c3f-b590-aa104ff17fc9.png">

---

#### Conor Corge (person)
<img width="936" alt="03-conor-corge-person" src="https://user-images.githubusercontent.com/10484515/208252245-926a4955-31c4-4752-b6f5-2bb96f75176e.png">

---

#### Stagecraft Ltd (company)
<img width="929" alt="04-stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252246-836c94a9-72dd-4de0-be55-d0629413503b.png">

---

#### Ferdinand Foo (person)
<img width="933" alt="05-ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/208252248-0a19a4c9-7229-45fc-8d17-01f52705bee2.png">

---

#### Sub-Wibble at Jerwood Theatre Upstairs (production)
N.B. Nominations/awards for its sur-production are now captured via association
<img width="948" alt="06-sub-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/224575492-cc3e01cd-23bf-49a5-85d9-fd3a89bdf7d2.png">

---

#### Sur-Wibble at Jerwood Theatre Upstairs (production)
N.B. Nominations/awards for its sub-productions are now captured via association
<img width="952" alt="07-sur-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/224575497-96cb36d9-0fd9-424a-9add-f969ba423b2f.png">

---

#### Sub-Wibble at Duke of York's Theatre (production)
N.B. Nominations/awards for its sur-production are now captured via association
<img width="920" alt="08-sub-wibble-at-duke-of-yorks-theatre-production" src="https://user-images.githubusercontent.com/10484515/224575499-917b2afa-71f8-4a04-a1f5-fc3c15490b50.png">

---

#### Sur-Wibble at Duke of York's Theatre (production)
N.B. Nominations/awards for its sub-productions are now captured via association
<img width="951" alt="09-sur-wibble-at-duke-of-yorks-theatre-production" src="https://user-images.githubusercontent.com/10484515/224575501-ebd0a7f1-86e0-4eb3-8e25-e4a674867097.png">

---

#### Sub-Wibble (play) (material)
<img width="943" alt="10-sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/208252256-2e9b41d1-8907-4c88-b0f8-0118331b7131.png">

---

#### Sur-Wibble (trilogy of plays) (material)
<img width="935" alt="11-sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/208252259-665249ec-2bb9-4dfe-998e-3350add933a4.png">

---

### `material-with-sub-materials-source-materials.test.js`

#### Bring Up the Bodies (novel) (material)
<img width="935" alt="01-bring-up-the-bodies-novel-material" src="https://user-images.githubusercontent.com/10484515/208252378-22d1e8f0-6f71-46fa-bbdb-55aacdc8254c.png">

---

### `prod-with-sub-prods.test.js`

#### The Coast of Utopia at Olivier Theatre (production with sub-productions that have a sur-venue)
<img width="503" alt="01-the-coast-of-utopia-at-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/208252403-5ac76bab-7f91-4f06-90a3-0fae36857294.png">

---

#### Voyage at Olivier Theatre (production with sur-production that has a sur-venue)
<img width="557" alt="02-voyage-at-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/208252405-ff12bcc5-122c-4ee0-bbcf-fc8662f75579.png">

---

#### The Coast of Utopia at Vivian Beaumont Theatre (production with sub-productions that do not have a sur-venue)
<img width="468" alt="03-the-coast-of-utopia-at-vivian-beaumont-theatre-production" src="https://user-images.githubusercontent.com/10484515/208252406-b9a82088-71aa-4eed-a98b-c3baba007373.png">

---

#### Voyage at Vivian Beaumont Theatre (production with sur-production that does not have a sur-venue)
<img width="506" alt="04-voyage-at-vivian-beaumont-theatre-production" src="https://user-images.githubusercontent.com/10484515/208252407-53d32748-e71f-4587-b861-bbfaabc8db80.png">

---

#### Voyage (material)
<img width="610" alt="05-voyage-material" src="https://user-images.githubusercontent.com/10484515/208252408-3771bfbc-f9c2-4026-bfb4-61f7195f9ba0.png">

---

#### The Coast of Utopia (material)
<img width="561" alt="06-the-coast-of-utopia-material" src="https://user-images.githubusercontent.com/10484515/208252409-48859c76-05d4-4875-8de3-8fca7164628b.png">

---

#### National Theatre (venue)
<img width="520" alt="07-national-theatre-venue" src="https://user-images.githubusercontent.com/10484515/208252410-b05c432f-937d-41db-8e98-02b2f748ebb9.png">

---

#### Olivier Theatre (venue)
<img width="540" alt="08-olivier-theatre-venue" src="https://user-images.githubusercontent.com/10484515/208252411-b21d0239-00e4-4b14-8b86-249a89bfcce4.png">

---

#### Trevor Nunn (person)
<img width="934" alt="09-trevor-nunn-person" src="https://user-images.githubusercontent.com/10484515/208252412-df220499-a407-4c8f-96a1-5a4126a61664.png">

---

#### National Theatre Company (company)
<img width="927" alt="10-national-theatre-company" src="https://user-images.githubusercontent.com/10484515/208252413-931d7f77-8ddd-45fc-903a-1476c088d2ac.png">

---

#### Nick Starr (person)
<img width="923" alt="11-nick-starr-person" src="https://user-images.githubusercontent.com/10484515/208252414-640ec4fb-df8c-4b9c-a5fd-12f4f17dba8f.png">

---

#### Stephen Dillane (person)
<img width="753" alt="12-stephen-dillane-person" src="https://user-images.githubusercontent.com/10484515/208252415-1036f5bd-0370-4284-81ae-ac8ae42916bb.png">

---

#### Steven Edis (person)
<img width="937" alt="13-steven-edis-person" src="https://user-images.githubusercontent.com/10484515/208252416-408a340f-cf24-467f-acee-b7a82a46540d.png">

---

#### Musical Direction Ltd (company)
<img width="934" alt="14-musical-direction-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252417-ebaf6e33-2bbc-4adb-b62e-aa639f3d6a1b.png">

---

#### Mark Bousie (person)
<img width="932" alt="15-mark-bousie-person" src="https://user-images.githubusercontent.com/10484515/208252418-66ee11c0-156e-41a9-b4d7-b73ef725722d.png">

---

#### Fiona Bardsley (person)
<img width="939" alt="16-fiona-bardsley-person" src="https://user-images.githubusercontent.com/10484515/208252420-e1d2c7d2-430e-4e94-bb85-fdd713165f9d.png">

---

#### Stage Management Ltd (company)
<img width="929" alt="17-stage-management-ltd-company" src="https://user-images.githubusercontent.com/10484515/208252421-cd32d791-f341-416a-a533-016e90d40107.png">

---

#### Sue Millin (person)
<img width="939" alt="18-sue-millin-person" src="https://user-images.githubusercontent.com/10484515/208252422-b6d7fa18-b7d0-4951-bb90-d7e31c2733ee.png">

---

#### Alexander Herzen (character)
<img width="934" alt="19-alexander-herzen-character" src="https://user-images.githubusercontent.com/10484515/208252423-06c86896-d609-427f-87bc-6879bb81e595.png">

---

#### Productions list
<img width="627" alt="20-productions-list" src="https://user-images.githubusercontent.com/10484515/208252424-58189fb6-cf96-4bd5-9bf9-7219adc95753.png">