### PR TITLE
Change title text colour to default text colour

### DIFF
--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -21,7 +21,7 @@ body {
 }
 
 a {
-	color: color-variables.$theme-color;
+	color: color-variables.$interactive-text-color;
 
 	&:hover {
 		color: color-variables.$default-text-color;

--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -4,7 +4,7 @@
 	margin: 0 5px 20px 5px;
 	padding-bottom: 0px;
 	font-size: xx-large;
-	color: color-variables.$theme-color;
+	color: color-variables.$default-text-color;
 }
 
 .fictional-name-text {

--- a/src/client/stylesheets/lib/_color-variables.scss
+++ b/src/client/stylesheets/lib/_color-variables.scss
@@ -6,4 +6,4 @@ $header-background-color: #000000;
 $header-text-color: #1975A3;
 $header-text-color-hover: #3083AC;
 $html-background-color: #F0F0F0;
-$theme-color: #006699;
+$interactive-text-color: #006699;


### PR DESCRIPTION
This PR changes the title text colour from the theme colour to the default text colour.

The decision has been made because the theme colour is used to denote that text is a link so is inconsistent and misleading to be used for the title text (which is not a link).

#### Before:
<img width="415" alt="before" src="https://user-images.githubusercontent.com/10484515/212739316-a20ee7b1-b55d-4f6c-a1b8-6140b729c578.png">

---

#### After:
<img width="413" alt="after" src="https://user-images.githubusercontent.com/10484515/212739323-425645d3-eba9-4482-afac-9abc7b14e827.png">