### PR TITLE
Display material sub-sub-materials

### DIFF
--- a/src/client/stylesheets/_list.scss
+++ b/src/client/stylesheets/_list.scss
@@ -1,5 +1,9 @@
 .list {
 	list-style: disc inside;
+
+	& .list--nested {
+		margin-left: 20px;
+	}
 }
 
 .list--no-bullets {

--- a/src/components/ListWrapper.jsx
+++ b/src/components/ListWrapper.jsx
@@ -2,10 +2,10 @@ import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 const ListWrapper = props => {
 
-	const { children } = props;
+	const { isNested, children } = props;
 
 	return (
-		<ul className="list">
+		<ul className={isNested ? 'list--nested' : 'list'}>
 
 			{ children }
 

--- a/src/components/MaterialLinkWithContext.jsx
+++ b/src/components/MaterialLinkWithContext.jsx
@@ -10,6 +10,12 @@ const MaterialLinkWithContext = props => {
 		<Fragment>
 
 			{
+				material.surMaterial?.surMaterial && (
+					<PrependedSurInstance surInstance={material.surMaterial.surMaterial} />
+				)
+			}
+
+			{
 				material.surMaterial && (
 					<PrependedSurInstance surInstance={material.surMaterial} />
 				)

--- a/src/components/MaterialsList.jsx
+++ b/src/components/MaterialsList.jsx
@@ -4,16 +4,22 @@ import { ListWrapper, MaterialLinkWithContext } from '.';
 
 const MaterialsList = props => {
 
-	const { materials } = props;
+	const { materials, isNested } = props;
 
 	return (
-		<ListWrapper>
+		<ListWrapper isNested={isNested}>
 
 			{
 				materials.map((material, index) =>
 					<li key={index}>
 
 						<MaterialLinkWithContext material={material} />
+
+						{
+							material.subMaterials?.length > 0 && (
+								<MaterialsList materials={material.subMaterials} isNested={true} />
+							)
+						}
 
 					</li>
 				)

--- a/src/components/WritingEntities.jsx
+++ b/src/components/WritingEntities.jsx
@@ -15,6 +15,12 @@ const WritingEntities = props => {
 						<Fragment key={index}>
 
 							{
+								entity.surMaterial?.surMaterial && (
+									<PrependedSurInstance surInstance={entity.surMaterial.surMaterial} />
+								)
+							}
+
+							{
 								entity.surMaterial && (
 									<PrependedSurInstance surInstance={entity.surMaterial} />
 								)


### PR DESCRIPTION
Display material sub-sub-materials exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/519.

---

## Real-life examples

#### The Bomb: A Partial History (collection of plays) (material)
<img width="596" alt="the-bomb-a-partial-history-material" src="https://user-images.githubusercontent.com/10484515/221379768-a46c8be7-955e-4f89-b4a3-58e3975bf406.png">

---

#### First Blast: Proliferation (sub-collection of plays) (material)
<img width="606" alt="first-blast-proliferation-1940-1992-material" src="https://user-images.githubusercontent.com/10484515/221429298-02f164e1-c2ae-473c-a097-624d66e84874.png">

---

#### From Elsewhere: The Message… (play) (material)
<img width="592" alt="from-elsewhere-the-message-material" src="https://user-images.githubusercontent.com/10484515/221429359-dae6de7f-be46-4769-94d7-b34465897e38.png">

---

#### Zinnie Harris (person)
<img width="859" alt="zinnie-harris-person" src="https://user-images.githubusercontent.com/10484515/221379927-67ca543c-00cd-4064-b326-440fc2ebfe28.png">

---

#### Rudolf (character)
<img width="866" alt="rudolf-character" src="https://user-images.githubusercontent.com/10484515/221379945-030b2802-e0c5-4489-b285-86be6c2d620f.png">

---

#### From Elsewhere: The Message… at Tricycle Theatre (production)
<img width="847" alt="from-elsewhere-on-the-watch-production" src="https://user-images.githubusercontent.com/10484515/221379964-278a89b6-8763-4f7a-8594-5d34a216ab78.png">

---

#### Materials list
<img width="935" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/221379981-8393ad87-6866-4ed4-b865-9e2c4362c8b2.png">

---

## Test examples

### `award-ceremonies-with-crediting-sub-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="938" alt="wordsmith-award-2010-award-ceremony" src="https://user-images.githubusercontent.com/10484515/224542635-8b9c01a1-2436-4b12-9473-7ec574436ce5.png">

---

#### Playwriting Prize 2009 (award ceremony)
<img width="938" alt="playwriting-prize-2009-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221435836-8f378402-253e-4dc7-b37b-035db19aee03.png">

---

#### Dramatists Medal 2008 (award ceremony)
<img width="951" alt="dramatists-medal-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221435866-7c12812e-351c-44c9-84bb-fc35df13df73.png">

---

#### John Doe (person): credit for directly nominated material
<img width="943" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/224544533-d5c8d84f-78c8-4054-b84d-211d1cb8cd54.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="941" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/224544542-63c3f319-093f-4f4f-95c3-e2d2a41f208f.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
N.B. Nominations/awards for its sur-sur-material are now captured via association
<img width="936" alt="sub-plugh-material" src="https://user-images.githubusercontent.com/10484515/224544554-afe27447-e56b-447b-8bbb-a132319e98d1.png">

---

#### Mid-Plugh (sub-collection of plays, 1899) (material): subsequent versions have nominations
<img width="951" alt="mid-plugh-material" src="https://user-images.githubusercontent.com/10484515/224544564-cc5247e0-f73b-4acd-ae4f-858b9b26fae6.png">

---

#### Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations
N.B. Nominations/awards for its sub-sub-materials are now captured via association
<img width="940" alt="sur-plugh-material" src="https://user-images.githubusercontent.com/10484515/224544570-c6526f54-8621-4159-8436-633a84a418b0.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="939" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/224544587-c915d929-99c5-4a9d-b062-9939b4e87efc.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="942" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/224544595-a6171eb2-d185-475b-9cf1-dbd47a8807cb.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
N.B. Nominations/awards for its sur-sur-material are now captured via association
<img width="928" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/224544602-263ba2a7-108f-4e83-ba4c-7ad68075a3a2.png">

---

#### Mid-Waldo (sub-trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="937" alt="mid-waldo-material" src="https://user-images.githubusercontent.com/10484515/224544607-9bc76d3a-4df9-4e8c-9ce4-b33169f8b791.png">

---

#### Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations
N.B. Nominations/awards for its sub-sub-materials are now captured via association
<img width="942" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/224544611-050377ec-00b8-4bcf-b244-2a54f66902cd.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="937" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/224544616-d4ee1aa4-634a-4318-975c-f78c665f6f35.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="933" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/224544628-a58ce1d6-54d4-489d-b8c5-6d1489f475d5.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="944" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/224544632-bf8cb3d2-0793-4be8-9b2e-1863bc53f3cb.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="952" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/224544643-b9c5c5cc-6766-4f27-b676-4e6d1ae99b8a.png">

---

### `award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="934" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/224557939-ef5e1a6b-fb8b-45c7-bdfd-07bd59474847.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="928" alt="evening-standard-theatre-awards-2019-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221436813-8e9e837d-4e01-41d3-a342-70f1b3746759.png">

---

#### Critics Circle Theatre Awards 2018 (award ceremony)
<img width="916" alt="critics-circle-theatre-awards-2018-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221436839-02d2b0af-6532-476c-8b28-939080a19fab.png">

---

#### Conor Corge (person)
<img width="949" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/224557954-4c3496fb-bd6c-4a0e-9fb9-25bcc0ee846b.png">

---

#### Stagecraft Ltd (company)
<img width="946" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/224557961-395a6f54-1001-4213-bca5-344ae6ff8955.png">

---

#### Ferdinand Foo (person)
<img width="950" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/224557970-c8d3e321-c5d3-415c-bd15-ea9c5373b54d.png">

---

#### Sub-Hoge at Noël Coward Theatre (production)
<img width="925" alt="sub-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/224577355-138d65c7-78fb-4fa8-ab9f-af9590549a3b.png">

---

#### Mid-Hoge at Noël Coward Theatre (production)
<img width="943" alt="mid-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/224577358-d3833d35-d45f-4e1b-84f0-9f6d687094cf.png">

---

#### Sur-Hoge at Noël Coward Theatre (production)
<img width="942" alt="sur-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/224577366-0fe6e2ce-a34e-4bfb-971e-27f0ed06ce27.png">

---

#### Sub-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="942" alt="sub-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/224577368-ca481e4e-f907-4f21-8e62-2c90ca3a6d67.png">

---

#### Mid-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="943" alt="mid-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/224577373-8e60fae3-5838-46df-bdd9-55147c760fc7.png">

---

#### Sur-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="947" alt="sur-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/224577379-26efde32-6322-4287-8f50-fd841e9662dc.png">

---

#### Sub-Wibble (play) (material)
N.B. Nominations/awards for its sur-sur-material are now captured via association
<img width="944" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/224558017-c4cd0cc0-6c01-4b2c-93c5-582742c972cc.png">

---

#### Mid-Wibble (play) (material)
<img width="938" alt="mid-wibble-material" src="https://user-images.githubusercontent.com/10484515/224558022-a6c1555a-e13b-4650-b6b3-c14dd5f63d04.png">

---

#### Sur-Wibble (trilogy of plays) (material)
N.B. Nominations/awards for its sub-sub-materials are now captured via association
<img width="953" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/224558029-229cbe93-eb8f-4aa0-8e50-50d08df2b48b.png">

---

### `material-with-sub-sub-materials-rights-grantor.test.js`

#### The Tolkien Estate (company)
<img width="937" alt="the-tolkien-estate-company" src="https://user-images.githubusercontent.com/10484515/224558465-b865c528-c2b4-4b21-8f52-be91d2b8e385.png">

---

#### Baillie Tolkien (person)
<img width="938" alt="baillie-tolkien-person" src="https://user-images.githubusercontent.com/10484515/224558469-608d70f1-13b8-48ab-bc04-d27b2729b31d.png">

---

### `material-with-sub-sub-materials-source-materials.test.js`

#### Genesis (religious text) (material)
<img width="925" alt="genesis-material" src="https://user-images.githubusercontent.com/10484515/224559638-b44a80af-6ec6-4603-becc-bdbae3452865.png">

---

#### Godblog (play) (material)
<img width="942" alt="godblog-material" src="https://user-images.githubusercontent.com/10484515/224559646-7032b887-6698-4a40-9e22-989a9e811306.png">

---

#### Richard Bancroft (person)
<img width="937" alt="richard-bancroft-person" src="https://user-images.githubusercontent.com/10484515/224559649-78f77e29-111b-4d6c-b618-ab51dc0a049c.png">

---

#### Jeanette Winterson (person)
<img width="936" alt="jeanette-winterson-person" src="https://user-images.githubusercontent.com/10484515/224559653-63a39371-670e-4d31-94ce-a4139813f921.png">

---

#### The Canterbury Editors (company)
<img width="936" alt="the-canterbury-editors-company" src="https://user-images.githubusercontent.com/10484515/224559659-ead8807a-c79e-4f51-8d70-79d12ee2370a.png">

---

#### Only Fruits (company)
<img width="928" alt="only-fruits-company" src="https://user-images.githubusercontent.com/10484515/224559663-8d8cb737-0ae9-455e-b2bc-f033836a65ca.png">

---

#### Godblog at Bush Theatre (production)
<img width="919" alt="godblog-at-bush-theatre-production" src="https://user-images.githubusercontent.com/10484515/224559671-e914cd8c-056e-461c-9a41-f7603bba3a4d.png">

---

#### God (character)
<img width="923" alt="god-character" src="https://user-images.githubusercontent.com/10484515/224559675-e5403537-8354-4b7a-b31e-4d5788a3d7d0.png">

---

#### Materials list
<img width="924" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/224559678-1185e3ea-cf39-4863-82df-7daf2a732b9a.png">

---

### `material-with-sub-sub-materials-subsequent-versions.test.js`

#### Richard II (original version) (material)
<img width="837" alt="richard-ii-original-version-material" src="https://user-images.githubusercontent.com/10484515/224559877-f7145e87-40d5-4e01-8822-b6cf50e63548.png">

---

#### Richard II (subsequent version) (material)
<img width="916" alt="richard-ii-subsequent-version-material" src="https://user-images.githubusercontent.com/10484515/224559883-70af5789-2936-43a0-96c7-8c7389fca58c.png">

---

#### William Shakespeare (person)
<img width="914" alt="william-shakespeare-person" src="https://user-images.githubusercontent.com/10484515/224559887-e0d87640-5e46-4fc0-b755-38a419d07789.png">

---

#### The King's Men (company)
<img width="912" alt="the-kings-men-company" src="https://user-images.githubusercontent.com/10484515/224559894-f52be89b-732b-4c3f-99a4-932ca60b82ce.png">

---

### `material-with-sub-sub-materials.test.js`

#### The Great Game: Afghanistan (material with sub-sub-materials)
<img width="640" alt="the-great-game-afghanistan-material" src="https://user-images.githubusercontent.com/10484515/224560497-4aaafc33-13ec-4d66-bc5d-0d24e5dc2332.png">

---

#### Part One - Invasions and Independence 1842-1930 (material with sur-material and sub-material)
<img width="818" alt="part-one-invasions-and-independence-1842-1930-material" src="https://user-images.githubusercontent.com/10484515/221438170-a4fadb6f-9e6b-47a2-9844-367cf94aedbb.png">

---

#### Bugles at the Gates of Jalalabad (material with sur-sur-material)
<img width="705" alt="bugles-at-the-gate-of-jalalabad-material" src="https://user-images.githubusercontent.com/10484515/224560513-0485afa9-8859-455b-ab4b-7d6dcb3e7398.png">

---

#### Bar (character)
<img width="935" alt="bar-character" src="https://user-images.githubusercontent.com/10484515/224560523-47e18a99-a7b9-4e1b-9869-a6720611df2e.png">

---

#### The Great Game: Afghanistan at Tricycle Theatre (production)
<img width="511" alt="the-great-game-afghanistan-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/221438288-9598dc60-eef7-48e4-9834-b8f382e109fb.png">

---

#### Part One - Invasions and Independence 1842-1930 at Tricycle Theatre (production)
<img width="819" alt="part-one-invasions-and-independence-1842-1930-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/221438310-971324d1-583f-4e80-a62d-af9595776bd7.png">

---

#### Bugles at the Gates of Jalalabad at Tricycle Theatre (production)
<img width="919" alt="bugles-at-the-gate-of-jalalabad-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/224560541-bcafd191-06b8-4789-8624-197ab4a757dc.png">

---

#### Ferdinand Foo (person)
<img width="931" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/224560544-9dbb9f7f-d405-4406-b64f-5df4f2f249fb.png">

---

#### Fictioneers Ltd (company)
<img width="935" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/224560552-8d53ba0d-6211-44a6-bd4a-a060567c6d94.png">

---

#### Materials list
<img width="947" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/224560567-f051d3ef-7562-4fc6-a8e8-42b8a1816510.png">