### PR TITLE
Display recipientProduction in Production instance page awards section

### DIFF
--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -2,7 +2,9 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import {
 	App,
+	AppendedProductionDates,
 	AppendedRoles,
+	AppendedVenue,
 	CommaSeparatedMaterials,
 	CommaSeparatedProductions,
 	Entities,
@@ -215,6 +217,37 @@ const Production = props => {
 																					}
 
 																					{
+																						nomination.entities.length > 0 && nomination.recipientProduction && (
+																							<Fragment>{';'}</Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.recipientProduction && (
+																							<Fragment>
+																								<Fragment>{' (for '}</Fragment>
+																								<InstanceLink instance={nomination.recipientProduction} />
+																								{
+																									nomination.recipientProduction.venue && (
+																										<AppendedVenue venue={nomination.recipientProduction.venue} />
+																									)
+																								}
+
+																								{
+																									(nomination.recipientProduction.startDate || nomination.recipientProduction.endDate) && (
+																										<AppendedProductionDates
+																											startDate={nomination.recipientProduction.startDate}
+																											endDate={nomination.recipientProduction.endDate}
+																										/>
+																									)
+																								}
+																								<Fragment>{')'}</Fragment>
+																							</Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.recipientProduction &&
 																						nomination.coProductions.length > 0 && (
 																							<Fragment>
 																								<Fragment>{' (with '}</Fragment>


### PR DESCRIPTION
This PR displays (if applicable) the recipient production in the Production instance page awards section.

The equivalent work was done for recipient materials in https://github.com/andygout/theatrebase-ssr/pull/190 but forgotten in this PR https://github.com/andygout/theatrebase-ssr/pull/203 where it should have been included.

---

#### Before
<img width="951" alt="before" src="https://user-images.githubusercontent.com/10484515/224540784-19c786bc-8939-4675-b5e0-fc5a5b92a2d2.png">

---

#### After
<img width="940" alt="after" src="https://user-images.githubusercontent.com/10484515/224540791-a68f338d-c1f5-466a-b9c9-e1dce65662b8.png">