### PR TITLE
Display material instance's sur and sub-material credits

### DIFF
--- a/src/client/stylesheets/_list.scss
+++ b/src/client/stylesheets/_list.scss
@@ -1,9 +1,5 @@
 .list {
 	list-style: disc inside;
-
-	& .list--nested {
-		margin-left: 20px;
-	}
 }
 
 .list--no-bullets {

--- a/src/components/ListWrapper.jsx
+++ b/src/components/ListWrapper.jsx
@@ -2,10 +2,10 @@ import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
 const ListWrapper = props => {
 
-	const { isNested, children } = props;
+	const { children } = props;
 
 	return (
-		<ul className={isNested ? 'list--nested' : 'list'}>
+		<ul className="list">
 
 			{ children }
 

--- a/src/components/MaterialsList.jsx
+++ b/src/components/MaterialsList.jsx
@@ -4,22 +4,16 @@ import { ListWrapper, MaterialLinkWithContext } from '.';
 
 const MaterialsList = props => {
 
-	const { materials, isNested } = props;
+	const { materials } = props;
 
 	return (
-		<ListWrapper isNested={isNested}>
+		<ListWrapper>
 
 			{
 				materials.map((material, index) =>
 					<li key={index}>
 
 						<MaterialLinkWithContext material={material} />
-
-						{
-							material.subMaterials?.length > 0 && (
-								<MaterialsList materials={material.subMaterials} isNested={true} />
-							)
-						}
 
 					</li>
 				)

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -21,499 +21,541 @@ const Material = props => {
 
 	const { currentPath, documentTitle, pageTitle, material } = props;
 
-	const {
-		model,
-		format,
-		year,
-		writingCredits,
-		surMaterial,
-		subMaterials,
-		characterGroups,
-		originalVersionMaterial,
-		subsequentVersionMaterials,
-		productions,
-		sourcingMaterials,
-		sourcingMaterialProductions,
-		awards,
-		subsequentVersionMaterialAwards,
-		sourcingMaterialAwards
-	} = material;
+	const renderMaterial = material => {
 
-	return (
-		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+		const {
+			format,
+			year,
+			writingCredits,
+			surMaterial,
+			subMaterials,
+			characterGroups,
+			originalVersionMaterial,
+			subsequentVersionMaterials,
+			productions,
+			sourcingMaterials,
+			sourcingMaterialProductions,
+			awards,
+			subsequentVersionMaterialAwards,
+			sourcingMaterialAwards
+		} = material;
 
-			{
-				format && (
-					<InstanceFacet labelText='Format'>
+		return (
+			<Fragment>
 
-						<Fragment>{ capitalise(format) }</Fragment>
+				{
+					format && (
+						<InstanceFacet labelText='Format'>
 
-					</InstanceFacet>
-				)
-			}
+							<Fragment>{ capitalise(format) }</Fragment>
 
-			{
-				year && (
-					<InstanceFacet labelText='Year'>
+						</InstanceFacet>
+					)
+				}
 
-						<Fragment>{ year }</Fragment>
+				{
+					year && (
+						<InstanceFacet labelText='Year'>
 
-					</InstanceFacet>
-				)
-			}
+							<Fragment>{ year }</Fragment>
 
-			{
-				writingCredits?.length > 0 && (
-					<InstanceFacet labelText='Writers'>
+						</InstanceFacet>
+					)
+				}
 
-						<WritingCredits credits={writingCredits} isAppendage={false} />
+				{
+					writingCredits?.length > 0 && (
+						<InstanceFacet labelText='Writers'>
 
-					</InstanceFacet>
-				)
-			}
+							<WritingCredits credits={writingCredits} isAppendage={false} />
 
-			{
-				surMaterial && (
-					<InstanceFacet labelText='Part of'>
+						</InstanceFacet>
+					)
+				}
 
-						<MaterialLinkWithContext material={surMaterial} />
+				{
+					surMaterial && (
+						<InstanceFacet labelText='Part of'>
 
-					</InstanceFacet>
-				)
-			}
+							<div className="nested-instance">
 
-			{
-				subMaterials?.length > 0 && (
-					<InstanceFacet labelText='Comprises'>
+								<InstanceFacet labelText='Material'>
 
-						<MaterialsList materials={subMaterials} />
+									<InstanceLink instance={surMaterial} />
 
-					</InstanceFacet>
-				)
-			}
+								</InstanceFacet>
 
-			{
-				characterGroups?.length > 0 && (
-					<InstanceFacet labelText='Characters'>
+								{
+									renderMaterial(surMaterial)
+								}
+
+							</div>
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					subMaterials?.length > 0 && (
+						<InstanceFacet labelText='Comprises'>
 
 						{
-							characterGroups.length === 1
-								? (
-									<Fragment>
+							subMaterials
+								.map((subMaterial, index) =>
+									<div key={index} className="nested-instance">
+
+										<InstanceFacet labelText='Material'>
+
+											<InstanceLink instance={subMaterial} />
+
+										</InstanceFacet>
 
 										{
-											Boolean(characterGroups[0].name) && (
-												<div className="instance-facet-subheader">
-
-													{ characterGroups[0].name }
-
-												</div>
-											)
+											renderMaterial(subMaterial)
 										}
 
-										<CharactersList characters={characterGroups[0].characters} />
+									</div>
+								)
+						}
 
+						</InstanceFacet>
+					)
+				}
+
+				{
+					characterGroups?.length > 0 && (
+						<InstanceFacet labelText='Characters'>
+
+							{
+								characterGroups.length === 1
+									? (
+										<Fragment>
+
+											{
+												Boolean(characterGroups[0].name) && (
+													<div className="instance-facet-subheader">
+
+														{ characterGroups[0].name }
+
+													</div>
+												)
+											}
+
+											<CharactersList characters={characterGroups[0].characters} />
+
+										</Fragment>
+									)
+									: (
+										<ul className="list list--no-bullets">
+
+											{
+												characterGroups.map((characterGroup, index) =>
+													<li key={index} className="instance-facet-group">
+
+														{
+															Boolean(characterGroup.name) && (
+																<div className="instance-facet-subheader">
+
+																	{ characterGroup.name }
+
+																</div>
+															)
+														}
+
+														<CharactersList characters={characterGroup.characters} />
+
+													</li>
+												)
+											}
+
+										</ul>
+									)
+							}
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					originalVersionMaterial && (
+						<InstanceFacet labelText='Original version'>
+
+							<MaterialLinkWithContext material={originalVersionMaterial} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					subsequentVersionMaterials?.length > 0 && (
+						<InstanceFacet labelText='Subsequent versions'>
+
+							<MaterialsList materials={subsequentVersionMaterials} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					productions?.length > 0 && (
+						<InstanceFacet labelText='Productions'>
+
+							<ProductionsList productions={productions} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					sourcingMaterials?.length > 0 && (
+						<InstanceFacet labelText='Materials as source material'>
+
+							<MaterialsList materials={sourcingMaterials} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					sourcingMaterialProductions?.length > 0 && (
+						<InstanceFacet labelText='Productions of materials as source material'>
+
+							<ProductionsList productions={sourcingMaterialProductions} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					awards?.length > 0 && (
+						<InstanceFacet labelText='Awards'>
+
+							{
+								awards.map((award, index) =>
+									<Fragment key={index}>
+										<InstanceLink instance={award} />
+
+										<ListWrapper>
+
+											{
+												award.ceremonies.map((ceremony, index) =>
+													<li key={index}>
+														<InstanceLink instance={ceremony} />{': '}
+
+														{
+															ceremony.categories
+																.map((category, index) =>
+																	<Fragment key={index}>
+																		{ category.name }{': '}
+
+																		{
+																			category.nominations
+																				.map((nomination, index) =>
+																					<Fragment key={index}>
+																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																							{nomination.type}
+																						</span>
+
+																						{
+																							nomination.entities.length > 0 && (
+																								<Fragment>
+																									<Fragment>{': '}</Fragment>
+																									<Entities
+																										entities={nomination.entities}
+																									/>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.productions.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' for '}</Fragment>
+																									<CommaSeparatedProductions
+																										productions={nomination.productions}
+																									/>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.productions.length > 0 &&
+																							(nomination.recipientMaterial || nomination.coMaterials.length > 0) && (
+																								<Fragment>{';'}</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.recipientMaterial && (
+																								<Fragment>
+																									<Fragment>{' (for '}</Fragment>
+																									<InstanceLink instance={nomination.recipientMaterial} />
+																									{
+																										(nomination.recipientMaterial.format || nomination.recipientMaterial.year) && (
+																											<AppendedFormatAndYear
+																												format={nomination.recipientMaterial.format}
+																												year={nomination.recipientMaterial.year}
+																											/>
+																										)
+																									}
+																									<Fragment>{')'}</Fragment>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.recipientMaterial &&
+																							nomination.coMaterials.length > 0 && (
+																								<Fragment>{';'}</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.coMaterials.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' (with '}</Fragment>
+																									<CommaSeparatedMaterials
+																										materials={nomination.coMaterials}
+																									/>
+																									<Fragment>{')'}</Fragment>
+																								</Fragment>
+																							)
+																						}
+																					</Fragment>
+																				)
+																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
+																		}
+																	</Fragment>
+																)
+																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
+														}
+													</li>
+												)
+											}
+
+										</ListWrapper>
 									</Fragment>
 								)
-								: (
-									<ul className="list list--no-bullets">
+							}
 
-										{
-											characterGroups.map((characterGroup, index) =>
-												<li key={index} className="instance-facet-group">
+						</InstanceFacet>
+					)
+				}
 
-													{
-														Boolean(characterGroup.name) && (
-															<div className="instance-facet-subheader">
+				{
+					subsequentVersionMaterialAwards?.length > 0 && (
+						<InstanceFacet labelText='Awards for subsequent versions'>
 
-																{ characterGroup.name }
+							{
+								subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
+									<Fragment key={index}>
+										<InstanceLink instance={subsequentVersionMaterialAward} />
 
-															</div>
-														)
-													}
+										<ListWrapper>
 
-													<CharactersList characters={characterGroup.characters} />
+											{
+												subsequentVersionMaterialAward.ceremonies.map((ceremony, index) =>
+													<li key={index}>
+														<InstanceLink instance={ceremony} />{': '}
 
-												</li>
-											)
-										}
+														{
+															ceremony.categories
+																.map((category, index) =>
+																	<Fragment key={index}>
+																		{ category.name }{': '}
 
-									</ul>
+																		{
+																			category.nominations
+																				.map((nomination, index) =>
+																					<Fragment key={index}>
+																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																							{nomination.type}
+																						</span>
+
+																						{
+																							nomination.subsequentVersionMaterials.length > 0 && (
+																								<Fragment>
+																									<Fragment>{': '}</Fragment>
+																									<CommaSeparatedMaterials
+																										materials={nomination.subsequentVersionMaterials}
+																									/>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.entities.length > 0 && (
+																								<Fragment>
+																									<Fragment>{': '}</Fragment>
+																									<Entities
+																										entities={nomination.entities}
+																									/>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.productions.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' for '}</Fragment>
+																									<CommaSeparatedProductions
+																										productions={nomination.productions}
+																									/>
+																								</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.productions.length > 0 &&
+																							nomination.materials.length > 0 && (
+																								<Fragment>{';'}</Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.materials.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' (with '}</Fragment>
+																									<CommaSeparatedMaterials
+																										materials={nomination.materials}
+																									/>
+																									<Fragment>{')'}</Fragment>
+																								</Fragment>
+																							)
+																						}
+																					</Fragment>
+																				)
+																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
+																		}
+																	</Fragment>
+																)
+																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
+														}
+													</li>
+												)
+											}
+
+										</ListWrapper>
+									</Fragment>
 								)
-						}
+							}
 
-					</InstanceFacet>
-				)
-			}
+						</InstanceFacet>
+					)
+				}
 
-			{
-				originalVersionMaterial && (
-					<InstanceFacet labelText='Original version'>
+				{
+					sourcingMaterialAwards?.length > 0 && (
+						<InstanceFacet labelText='Awards for materials as source material'>
 
-						<MaterialLinkWithContext material={originalVersionMaterial} />
+							{
+								sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
+									<Fragment key={index}>
+										<InstanceLink instance={sourcingMaterialAward} />
 
-					</InstanceFacet>
-				)
-			}
+										<ListWrapper>
 
-			{
-				subsequentVersionMaterials?.length > 0 && (
-					<InstanceFacet labelText='Subsequent versions'>
+											{
+												sourcingMaterialAward.ceremonies.map((ceremony, index) =>
+													<li key={index}>
+														<InstanceLink instance={ceremony} />{': '}
 
-						<MaterialsList materials={subsequentVersionMaterials} />
+														{
+															ceremony.categories
+																.map((category, index) =>
+																	<Fragment key={index}>
+																		{ category.name }{': '}
 
-					</InstanceFacet>
-				)
-			}
+																		{
+																			category.nominations
+																				.map((nomination, index) =>
+																					<Fragment key={index}>
+																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
+																							{nomination.type}
+																						</span>
 
-			{
-				productions?.length > 0 && (
-					<InstanceFacet labelText='Productions'>
+																						{
+																							nomination.sourcingMaterials.length > 0 && (
+																								<Fragment>
+																									<Fragment>{': '}</Fragment>
+																									<CommaSeparatedMaterials
+																										materials={nomination.sourcingMaterials}
+																									/>
+																								</Fragment>
+																							)
+																						}
 
-						<ProductionsList productions={productions} />
+																						{
+																							nomination.entities.length > 0 && (
+																								<Fragment>
+																									<Fragment>{': '}</Fragment>
+																									<Entities
+																										entities={nomination.entities}
+																									/>
+																								</Fragment>
+																							)
+																						}
 
-					</InstanceFacet>
-				)
-			}
+																						{
+																							nomination.productions.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' for '}</Fragment>
+																									<CommaSeparatedProductions
+																										productions={nomination.productions}
+																									/>
+																								</Fragment>
+																							)
+																						}
 
-			{
-				sourcingMaterials?.length > 0 && (
-					<InstanceFacet labelText='Materials as source material'>
+																						{
+																							nomination.productions.length > 0 &&
+																							nomination.materials.length > 0 && (
+																								<Fragment>{';'}</Fragment>
+																							)
+																						}
 
-						<MaterialsList materials={sourcingMaterials} />
+																						{
+																							nomination.materials.length > 0 && (
+																								<Fragment>
+																									<Fragment>{' (with '}</Fragment>
+																									<CommaSeparatedMaterials
+																										materials={nomination.materials}
+																									/>
+																									<Fragment>{')'}</Fragment>
+																								</Fragment>
+																							)
+																						}
+																					</Fragment>
+																				)
+																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
+																		}
+																	</Fragment>
+																)
+																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
+														}
+													</li>
+												)
+											}
 
-					</InstanceFacet>
-				)
-			}
+										</ListWrapper>
+									</Fragment>
+								)
+							}
 
-			{
-				sourcingMaterialProductions?.length > 0 && (
-					<InstanceFacet labelText='Productions of materials as source material'>
+						</InstanceFacet>
+					)
+				}
 
-						<ProductionsList productions={sourcingMaterialProductions} />
+			</Fragment>
+		);
 
-					</InstanceFacet>
-				)
-			}
+	};
 
-			{
-				awards?.length > 0 && (
-					<InstanceFacet labelText='Awards'>
-
-						{
-							awards.map((award, index) =>
-								<Fragment key={index}>
-									<InstanceLink instance={award} />
-
-									<ListWrapper>
-
-										{
-											award.ceremonies.map((ceremony, index) =>
-												<li key={index}>
-													<InstanceLink instance={ceremony} />{': '}
-
-													{
-														ceremony.categories
-															.map((category, index) =>
-																<Fragment key={index}>
-																	{ category.name }{': '}
-
-																	{
-																		category.nominations
-																			.map((nomination, index) =>
-																				<Fragment key={index}>
-																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
-																						{nomination.type}
-																					</span>
-
-																					{
-																						nomination.entities.length > 0 && (
-																							<Fragment>
-																								<Fragment>{': '}</Fragment>
-																								<Entities
-																									entities={nomination.entities}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' for '}</Fragment>
-																								<CommaSeparatedProductions
-																									productions={nomination.productions}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 &&
-																						(nomination.recipientMaterial || nomination.coMaterials.length > 0) && (
-																							<Fragment>{';'}</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.recipientMaterial && (
-																							<Fragment>
-																								<Fragment>{' (for '}</Fragment>
-																								<InstanceLink instance={nomination.recipientMaterial} />
-																								{
-																									(nomination.recipientMaterial.format || nomination.recipientMaterial.year) && (
-																										<AppendedFormatAndYear
-																											format={nomination.recipientMaterial.format}
-																											year={nomination.recipientMaterial.year}
-																										/>
-																									)
-																								}
-																								<Fragment>{')'}</Fragment>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.recipientMaterial &&
-																						nomination.coMaterials.length > 0 && (
-																							<Fragment>{';'}</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.coMaterials.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' (with '}</Fragment>
-																								<CommaSeparatedMaterials
-																									materials={nomination.coMaterials}
-																								/>
-																								<Fragment>{')'}</Fragment>
-																							</Fragment>
-																						)
-																					}
-																				</Fragment>
-																			)
-																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
-																	}
-																</Fragment>
-															)
-															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
-													}
-												</li>
-											)
-										}
-
-									</ListWrapper>
-								</Fragment>
-							)
-						}
-
-					</InstanceFacet>
-				)
-			}
+	return (
+		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={material.model}>
 
 			{
-				subsequentVersionMaterialAwards?.length > 0 && (
-					<InstanceFacet labelText='Awards for subsequent versions'>
-
-						{
-							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-								<Fragment key={index}>
-									<InstanceLink instance={subsequentVersionMaterialAward} />
-
-									<ListWrapper>
-
-										{
-											subsequentVersionMaterialAward.ceremonies.map((ceremony, index) =>
-												<li key={index}>
-													<InstanceLink instance={ceremony} />{': '}
-
-													{
-														ceremony.categories
-															.map((category, index) =>
-																<Fragment key={index}>
-																	{ category.name }{': '}
-
-																	{
-																		category.nominations
-																			.map((nomination, index) =>
-																				<Fragment key={index}>
-																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
-																						{nomination.type}
-																					</span>
-
-																					{
-																						nomination.subsequentVersionMaterials.length > 0 && (
-																							<Fragment>
-																								<Fragment>{': '}</Fragment>
-																								<CommaSeparatedMaterials
-																									materials={nomination.subsequentVersionMaterials}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.entities.length > 0 && (
-																							<Fragment>
-																								<Fragment>{': '}</Fragment>
-																								<Entities
-																									entities={nomination.entities}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' for '}</Fragment>
-																								<CommaSeparatedProductions
-																									productions={nomination.productions}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 &&
-																						nomination.materials.length > 0 && (
-																							<Fragment>{';'}</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.materials.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' (with '}</Fragment>
-																								<CommaSeparatedMaterials
-																									materials={nomination.materials}
-																								/>
-																								<Fragment>{')'}</Fragment>
-																							</Fragment>
-																						)
-																					}
-																				</Fragment>
-																			)
-																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
-																	}
-																</Fragment>
-															)
-															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
-													}
-												</li>
-											)
-										}
-
-									</ListWrapper>
-								</Fragment>
-							)
-						}
-
-					</InstanceFacet>
-				)
-			}
-
-			{
-				sourcingMaterialAwards?.length > 0 && (
-					<InstanceFacet labelText='Awards for materials as source material'>
-
-						{
-							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-								<Fragment key={index}>
-									<InstanceLink instance={sourcingMaterialAward} />
-
-									<ListWrapper>
-
-										{
-											sourcingMaterialAward.ceremonies.map((ceremony, index) =>
-												<li key={index}>
-													<InstanceLink instance={ceremony} />{': '}
-
-													{
-														ceremony.categories
-															.map((category, index) =>
-																<Fragment key={index}>
-																	{ category.name }{': '}
-
-																	{
-																		category.nominations
-																			.map((nomination, index) =>
-																				<Fragment key={index}>
-																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
-																						{nomination.type}
-																					</span>
-
-																					{
-																						nomination.sourcingMaterials.length > 0 && (
-																							<Fragment>
-																								<Fragment>{': '}</Fragment>
-																								<CommaSeparatedMaterials
-																									materials={nomination.sourcingMaterials}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.entities.length > 0 && (
-																							<Fragment>
-																								<Fragment>{': '}</Fragment>
-																								<Entities
-																									entities={nomination.entities}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' for '}</Fragment>
-																								<CommaSeparatedProductions
-																									productions={nomination.productions}
-																								/>
-																							</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.productions.length > 0 &&
-																						nomination.materials.length > 0 && (
-																							<Fragment>{';'}</Fragment>
-																						)
-																					}
-
-																					{
-																						nomination.materials.length > 0 && (
-																							<Fragment>
-																								<Fragment>{' (with '}</Fragment>
-																								<CommaSeparatedMaterials
-																									materials={nomination.materials}
-																								/>
-																								<Fragment>{')'}</Fragment>
-																							</Fragment>
-																						)
-																					}
-																				</Fragment>
-																			)
-																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
-																	}
-																</Fragment>
-															)
-															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
-													}
-												</li>
-											)
-										}
-
-									</ListWrapper>
-								</Fragment>
-							)
-						}
-
-					</InstanceFacet>
-				)
+				renderMaterial(material)
 			}
 
 		</App>


### PR DESCRIPTION
Display a production instance's sur and sub-production credits as enabled by this API PR: https://github.com/andygout/theatrebase-api/pull/539.

---

## Real-life examples

#### The Coast of Utopia (material) - before
![the-coast-of-utopia-material-before](https://user-images.githubusercontent.com/10484515/236805072-0153e58f-23f4-4aef-b948-52c7272f9bb9.png)

---

#### The Coast of Utopia (material) - after
![the-coast-of-utopia-material-after](https://user-images.githubusercontent.com/10484515/236805107-371a5691-f101-444c-adb2-83b97437a4fe.png)

---

#### Voyage (material) - before
![voyage-material-before](https://user-images.githubusercontent.com/10484515/236805130-2e3d6ba6-28b9-4a12-8c58-aef4cca78b41.png)

---

#### Voyage (material) - after
![voyage-material-after](https://user-images.githubusercontent.com/10484515/236805159-81c97bcd-e02a-415d-be1b-5f16ed603483.png)

---

#### The Bomb: A Partial History (material) - before
![the-bomb-a-partial-history-material-before](https://user-images.githubusercontent.com/10484515/236805180-3fa6c756-a22e-4806-ad27-5d0357c4ea4b.png)

---

#### The Bomb: A Partial History (material) - after
![the-bomb-a-partial-history-material-after](https://user-images.githubusercontent.com/10484515/236805190-bef56c5d-a07a-44e2-8730-c320c7ba7219.png)

---

#### First Blast: Proliferation (1940-1992) (material) - before
![first-blast-proliferation-1940-1992-material-before](https://user-images.githubusercontent.com/10484515/236805285-cf6f9474-b57b-4ddb-8ff0-534ee3d82bf6.png)

---

#### First Blast: Proliferation (1940-1992) (material) - after
![first-blast-proliferation-1940-1992-material-after](https://user-images.githubusercontent.com/10484515/236805477-5041f1c2-67bf-4725-b329-6f1341bcc121.png)

---

#### From Elsewhere: The Message… (material) - before
![from-elsewhere-the-message…-material-before](https://user-images.githubusercontent.com/10484515/236805509-6af1a5c3-afa5-4f85-8975-e6d04b59bba3.png)

---

#### From Elsewhere: The Message… (material) - after
![from-elsewhere-the-message…-material-after](https://user-images.githubusercontent.com/10484515/236805524-0e82086e-dfec-495a-9ac0-fc15573e914d.png)

---

## Test examples

### `mat-with-sub-mats-subsequent-versions.test.js`

#### Agamemnon (subsequent version) (material) - before
![agamemnon-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236807849-fbc29c6e-3283-4c37-a0b5-9d025a24e8ce.png)

---

#### Agamemnon (subsequent version) (material) - after
![agamemnon-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236807978-64536941-2bb4-48e3-9a0c-757bcab1d1e2.png)

---

#### The Oresteia (subsequent version) (material) - before
![the-oresteia-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236807970-b191e5bb-2acd-4312-8eab-371c7e448021.png)

---

#### The Oresteia (subsequent version) (material) - after
![the-oresteia-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236807890-440d588b-00c6-4a1c-b08f-360b87f16e1c.png)

---

### `mat-with-sub-mats.test.js`

#### Voyage (material) (material with sur-material) - before
![voyage-material-before](https://user-images.githubusercontent.com/10484515/236809110-0352aa3d-5ae7-4ce0-ae4b-7382ef6968a9.png)

---

#### Voyage (material) (material with sur-material) - after
![voyage-material-after](https://user-images.githubusercontent.com/10484515/236809125-5d9ba3e6-c368-4b01-9cc8-f2a60439a326.png)

---

#### The Coast of Utopia (material) (material with sub-materials) - before
![the-coast-of-utopia-material-before](https://user-images.githubusercontent.com/10484515/236809076-d2826079-349c-4b4e-a421-aa20475b531d.png)

---

#### The Coast of Utopia (material) (material with sub-materials) - after
![the-coast-of-utopia-material-after](https://user-images.githubusercontent.com/10484515/236809096-78fea575-7e67-4070-9ac2-dd4dc6999ebf.png)

---

### `mat-with-sub-sub-mats-source-mats.test.js`

#### Godblog (material) - before
![godblog-material-before](https://user-images.githubusercontent.com/10484515/236810194-41cbabdf-eb5f-4066-bb80-99da1ba733be.png)

---

#### Godblog (material) - after
![godblog-material-after](https://user-images.githubusercontent.com/10484515/236810205-02899e26-4f19-4966-8176-d0e513aa9296.png)

---

### `mat-with-sub-sub-mats-subsequent-versions.test.js`

#### Richard II (subsequent version) (material) - before
![richard-ii-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811407-4c328887-a22a-4908-bf98-431e31fc4108.png)

---

#### Richard II (subsequent version) (material) - after
![richard-ii-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811429-aadca048-fa87-4505-b30a-19a02610778f.png)

---

#### The First Henriad (subsequent version) (material) - before
![the-first-henriad-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811445-ed430435-096b-40b5-aa63-1d530790f274.png)

---

#### The First Henriad (subsequent version) (material) - after
![the-first-henriad-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811458-cd9ef2e5-6f6b-4f02-898f-07f22a4ab8d3.png)

---

#### The Henriad (subsequent version) (material) - before
![the-henriad-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811479-0b93b31e-e659-4905-8b16-5dcadb3119cc.png)

---

#### The Henriad (subsequent version) (material) - before
![the-henriad-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811492-b65adcd1-a978-4123-be0c-83bfc11b2d3d.png)

---

### `mat-with-sub-sub-mats.test.js`

#### Bugles at the Gates of Jalalabad (material) (material with sur-sur-material) - before
![bugles-at-the-gates-of-jalalabad-material-before](https://user-images.githubusercontent.com/10484515/236812884-6eadd664-ee6f-40c0-a9aa-708583369eb1.png)

---

#### Bugles at the Gates of Jalalabad (material) (material with sur-sur-material) - after
![bugles-at-the-gates-of-jalalabad-material-after](https://user-images.githubusercontent.com/10484515/236812573-1a61a209-7b75-4558-af12-2da83cb6a03e.png)

---

#### Part One - Invasions and Independence 1842-1930 (material) (material with sur-material and sub-materials) - before
![part-one-invasions-and-independence-1842-1930-material-before](https://user-images.githubusercontent.com/10484515/236812899-3bf1c8c5-d565-44b3-b6da-da406ba6fbc5.png)

---

#### Part One - Invasions and Independence 1842-1930 (material)  (material with sur-material and sub-materials)- after
![part-one-invasions-and-independence-1842-1930-material-after](https://user-images.githubusercontent.com/10484515/236812588-02d7a131-2651-48ed-97bf-b7bdc1ce6d84.png)

---

#### The Great Game: Afghanistan (material) (material with sub-sub-materials) - before
![the-great-game-afghanistan-material-before](https://user-images.githubusercontent.com/10484515/236812919-73133a01-7e46-4f22-acfa-48a6c50d3c35.png)

---

#### The Great Game: Afghanistan (material) (material with sub-sub-materials) - after
![the-great-game-afghanistan-material-after](https://user-images.githubusercontent.com/10484515/236812605-6885cbbf-a74b-4c81-b058-40727c9e0beb.png)