### PR TITLE
Add festival serieses resource

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -17,6 +17,8 @@ const Navigation = () => {
 
 				<li><a href='/companies'>Companies</a></li>
 
+				<li><a href='/festival-serieses'>Festival serieses</a></li>
+
 				<li><a href='/festivals'>Festivals</a></li>
 
 				<li><a href='/materials'>Materials</a></li>

--- a/src/pages/instances/FestivalSeries.jsx
+++ b/src/pages/instances/FestivalSeries.jsx
@@ -1,0 +1,17 @@
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { App } from '../../components';
+
+const FestivalSeries = props => {
+
+	const { currentPath, documentTitle, pageTitle, festivalSeries } = props;
+
+	const { model } = festivalSeries;
+
+	return (
+		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={model} />
+	);
+
+};
+
+export default FestivalSeries;

--- a/src/pages/instances/index.js
+++ b/src/pages/instances/index.js
@@ -3,6 +3,7 @@ import AwardCeremony from './AwardCeremony';
 import Character from './Character';
 import Company from './Company';
 import Festival from './Festival';
+import FestivalSeries from './FestivalSeries';
 import Material from './Material';
 import Person from './Person';
 import Production from './Production';
@@ -15,6 +16,7 @@ export {
 	Character,
 	Company,
 	Festival,
+	FestivalSeries,
 	Material,
 	Person,
 	Production,

--- a/src/pages/lists/FestivalSerieses.jsx
+++ b/src/pages/lists/FestivalSerieses.jsx
@@ -1,0 +1,19 @@
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { App, InstanceLinksList } from '../../components';
+
+const FestivalSerieses = props => {
+
+	const { documentTitle, pageTitle, festivalSerieses } = props;
+
+	return (
+		<App documentTitle={documentTitle} pageTitle={pageTitle}>
+
+			<InstanceLinksList instances={festivalSerieses} />
+
+		</App>
+	);
+
+};
+
+export default FestivalSerieses;

--- a/src/pages/lists/index.js
+++ b/src/pages/lists/index.js
@@ -3,6 +3,7 @@ import AwardCeremonies from './AwardCeremonies';
 import Characters from './Characters';
 import Companies from './Companies';
 import Festivals from './Festivals';
+import FestivalSerieses from './FestivalSerieses';
 import Materials from './Materials';
 import People from './People';
 import Productions from './Productions';
@@ -15,6 +16,7 @@ export {
 	Characters,
 	Companies,
 	Festivals,
+	FestivalSerieses,
 	Materials,
 	People,
 	Productions,

--- a/src/router.js
+++ b/src/router.js
@@ -41,6 +41,12 @@ router.get('/festivals', (request, response, next) =>
 router.get('/festivals/:uuid', (request, response, next) =>
 	instancesController(request, response, next));
 
+router.get('/festival-serieses', (request, response, next) =>
+	listsController(request, response, next, PLURALISED_MODELS.FESTIVAL_SERIESES));
+
+router.get('/festival-serieses/:uuid', (request, response, next) =>
+	instancesController(request, response, next));
+
 router.get('/materials', (request, response, next) =>
 	listsController(request, response, next, PLURALISED_MODELS.MATERIALS));
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,6 +8,8 @@ const COMPANY = 'COMPANY';
 const COMPANIES = 'COMPANIES';
 const FESTIVAL = 'FESTIVAL';
 const FESTIVALS = 'FESTIVALS';
+const FESTIVAL_SERIES = 'FESTIVAL_SERIES';
+const FESTIVAL_SERIESES = 'FESTIVAL_SERIESES';
 const MATERIAL = 'MATERIAL';
 const MATERIALS = 'MATERIALS';
 const PERSON = 'PERSON';
@@ -25,6 +27,7 @@ const MODELS = {
 	[CHARACTER]: CHARACTER,
 	[COMPANY]: COMPANY,
 	[FESTIVAL]: FESTIVAL,
+	[FESTIVAL_SERIES]: FESTIVAL_SERIES,
 	[MATERIAL]: MATERIAL,
 	[PERSON]: PERSON,
 	[PRODUCTION]: PRODUCTION,
@@ -38,6 +41,7 @@ const MODEL_TO_DISPLAY_NAME_MAP = {
 	[CHARACTER]: 'character',
 	[COMPANY]: 'company',
 	[FESTIVAL]: 'festival',
+	[FESTIVAL_SERIES]: 'festival series',
 	[MATERIAL]: 'material',
 	[PERSON]: 'person',
 	[PRODUCTION]: 'production',
@@ -51,6 +55,7 @@ const MODEL_TO_PAGE_COMPONENT_MAP = {
 	[CHARACTER]: 'Character',
 	[COMPANY]: 'Company',
 	[FESTIVAL]: 'Festival',
+	[FESTIVAL_SERIES]: 'FestivalSeries',
 	[MATERIAL]: 'Material',
 	[PERSON]: 'Person',
 	[PRODUCTION]: 'Production',
@@ -64,6 +69,7 @@ const MODEL_TO_PROP_NAME_MAP = {
 	[CHARACTER]: 'character',
 	[COMPANY]: 'company',
 	[FESTIVAL]: 'festival',
+	[FESTIVAL_SERIES]: 'festivalSeries',
 	[MATERIAL]: 'material',
 	[PERSON]: 'person',
 	[PRODUCTION]: 'production',
@@ -77,6 +83,7 @@ const MODEL_TO_ROUTE_MAP = {
 	[CHARACTER]: 'characters',
 	[COMPANY]: 'companies',
 	[FESTIVAL]: 'festivals',
+	[FESTIVAL_SERIES]: 'festival-serieses',
 	[MATERIAL]: 'materials',
 	[PERSON]: 'people',
 	[PRODUCTION]: 'productions',
@@ -90,6 +97,7 @@ const PLURALISED_MODELS = {
 	[CHARACTERS]: CHARACTERS,
 	[COMPANIES]: COMPANIES,
 	[FESTIVALS]: FESTIVALS,
+	[FESTIVAL_SERIESES]: FESTIVAL_SERIESES,
 	[MATERIALS]: MATERIALS,
 	[PEOPLE]: PEOPLE,
 	[PRODUCTIONS]: PRODUCTIONS,
@@ -103,6 +111,7 @@ const PLURALISED_MODEL_TO_PAGE_COMPONENT_MAP = {
 	[CHARACTERS]: 'Characters',
 	[COMPANIES]: 'Companies',
 	[FESTIVALS]: 'Festivals',
+	[FESTIVAL_SERIESES]: 'FestivalSerieses',
 	[MATERIALS]: 'Materials',
 	[PEOPLE]: 'People',
 	[PRODUCTIONS]: 'Productions',
@@ -116,6 +125,7 @@ const PLURALISED_MODEL_TO_PROP_NAME_MAP = {
 	[CHARACTERS]: 'characters',
 	[COMPANIES]: 'companies',
 	[FESTIVALS]: 'festivals',
+	[FESTIVAL_SERIESES]: 'festivalSerieses',
 	[MATERIALS]: 'materials',
 	[PEOPLE]: 'people',
 	[PRODUCTIONS]: 'productions',
@@ -129,6 +139,7 @@ const PLURALISED_MODEL_TO_TITLE_MAP = {
 	[CHARACTERS]: 'Characters',
 	[COMPANIES]: 'Companies',
 	[FESTIVALS]: 'Festivals',
+	[FESTIVAL_SERIESES]: 'Festival serieses',
 	[MATERIALS]: 'Materials',
 	[PEOPLE]: 'People',
 	[PRODUCTIONS]: 'Productions',


### PR DESCRIPTION
This PR adds functionality to display festival data added in this API PR: https://github.com/andygout/theatrebase-api/pull/607.

N.B. The obsolete plural form of 'series' — 'serieses' — has been resurrected and employed so as to differentiate the singular and plural form of series.

---

#### Festival serieses list
<img width="313" alt="festival-series-list" src="https://github.com/andygout/theatrebase-api/assets/10484515/cbbff79e-b184-470d-a8a0-70ec3a4845ab">


---

#### HighTide Festival (festival series)
<img width="314" alt="festival-instance" src="https://github.com/andygout/theatrebase-api/assets/10484515/9fe13fd7-7a48-4680-8a41-f02c88719c80">