### PR TITLE
Display festival festival series

### DIFF
--- a/src/components/FestivalLinkWithContext.jsx
+++ b/src/components/FestivalLinkWithContext.jsx
@@ -1,0 +1,25 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { InstanceLink, PrependedSurInstance } from '.';
+
+const FestivalLinkWithContext = props => {
+
+	const { festival } = props;
+
+	return (
+		<Fragment>
+
+			{
+				festival.festivalSeries && (
+					<PrependedSurInstance surInstance={festival.festivalSeries} />
+				)
+			}
+
+			<InstanceLink instance={festival} />
+
+		</Fragment>
+	);
+
+};
+
+export default FestivalLinkWithContext;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -18,6 +18,7 @@ import CommaSeparatedProductions from './CommaSeparatedProductions';
 import CreativeProductionsList from './CreativeProductionsList';
 import CrewProductionsList from './CrewProductionsList';
 import Entities from './Entities';
+import FestivalLinkWithContext from './FestivalLinkWithContext';
 import Footer from './Footer';
 import Head from './Head';
 import Header from './Header';
@@ -63,6 +64,7 @@ export {
 	CreativeProductionsList,
 	CrewProductionsList,
 	Entities,
+	FestivalLinkWithContext,
 	Footer,
 	Head,
 	Header,

--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -12,6 +12,10 @@ export default instance => {
 			if (instance.award) title = `${instance.award.name} ${title}`;
 			return title;
 
+		case MODELS.FESTIVAL:
+			if (instance.festivalSeries) title = `${instance.festivalSeries.name} ${title}`;
+			return title;
+
 		case MODELS.VENUE:
 			if (instance.surVenue) title = `${instance.surVenue.name}: ${title}`;
 			return title;

--- a/src/pages/instances/Festival.jsx
+++ b/src/pages/instances/Festival.jsx
@@ -1,15 +1,25 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceFacet, ProductionsList } from '../../components';
+import { App, InstanceFacet, InstanceLink, ProductionsList } from '../../components';
 
 const Festival = props => {
 
 	const { currentPath, documentTitle, pageTitle, festival } = props;
 
-	const { model, productions } = festival;
+	const { model, festivalSeries, productions } = festival;
 
 	return (
 		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+
+			{
+				festivalSeries && (
+					<InstanceFacet labelText='Festival series'>
+
+						<InstanceLink instance={festivalSeries} />
+
+					</InstanceFacet>
+				)
+			}
 
 			{
 				productions?.length > 0 && (

--- a/src/pages/instances/FestivalSeries.jsx
+++ b/src/pages/instances/FestivalSeries.jsx
@@ -1,15 +1,27 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App } from '../../components';
+import { App, InstanceFacet, InstanceLinksList } from '../../components';
 
 const FestivalSeries = props => {
 
 	const { currentPath, documentTitle, pageTitle, festivalSeries } = props;
 
-	const { model } = festivalSeries;
+	const { model, festivals } = festivalSeries;
 
 	return (
-		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={model} />
+		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={model}>
+
+			{
+				festivals?.length > 0 && (
+					<InstanceFacet labelText='Comprises'>
+
+						<InstanceLinksList instances={festivals} />
+
+					</InstanceFacet>
+				)
+			}
+
+		</App>
 	);
 
 };

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -6,6 +6,7 @@ import {
 	CommaSeparatedMaterials,
 	CommaSeparatedProductions,
 	Entities,
+	FestivalLinkWithContext,
 	InstanceFacet,
 	InstanceLink,
 	ListWrapper,
@@ -110,7 +111,7 @@ const Production = props => {
 					festival && (
 						<InstanceFacet labelText='Festival'>
 
-							<InstanceLink instance={festival} />
+							<FestivalLinkWithContext festival={festival} />
 
 						</InstanceFacet>
 					)

--- a/src/pages/lists/Festivals.jsx
+++ b/src/pages/lists/Festivals.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { App, InstanceLinksList } from '../../components';
+import { App, InstanceLink, ListWrapper } from '../../components';
 
 const Festivals = props => {
 
@@ -9,7 +9,31 @@ const Festivals = props => {
 	return (
 		<App documentTitle={documentTitle} pageTitle={pageTitle}>
 
-			<InstanceLinksList instances={festivals} />
+			<ListWrapper>
+
+				{
+					festivals.map((festival, index) =>
+						<li key={index}>
+
+							{
+								festival.festivalSeries && (
+									<Fragment>
+
+										<InstanceLink instance={festival.festivalSeries} />
+
+										<Fragment>{': '}</Fragment>
+
+									</Fragment>
+								)
+							}
+
+							<InstanceLink instance={festival} />
+
+						</li>
+					)
+				}
+
+			</ListWrapper>
 
 		</App>
 	);


### PR DESCRIPTION
Display festival festival series (i.e. the festival series of which a festival is a run) exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/608.

---

#### Edinburgh International Festival 2006 (festival)
<img width="801" alt="edinburgh-international-festival-2006-festival" src="https://github.com/andygout/theatrebase-api/assets/10484515/ef4be010-4085-446c-8484-9a4ad5d7b436">

---

#### Edinburgh International Festival (festival series)
<img width="539" alt="edinburgh-international-festival-festival-series" src="https://github.com/andygout/theatrebase-api/assets/10484515/b98421fb-1a9f-4764-959b-66c9f07c7607">

---

#### Troilus and Cressida at King's Theatre (production)
<img width="604" alt="troilus-and-cressida-at-kings-theatre-production" src="https://github.com/andygout/theatrebase-api/assets/10484515/cc91d6e5-2749-4a85-addc-0f43e011cde5">

---

#### Festivals list
<img width="294" alt="festivals-list" src="https://github.com/andygout/theatrebase-api/assets/10484515/401dfce4-8be9-4a1f-9b49-736a33bd47d4">