### PR TITLE
Amend isAlternate indicator display

### DIFF
--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -32,13 +32,13 @@ const AppendedPerformers = props => {
 									)
 								}
 
-								{
-									performer.isAlternate && (
-										<Fragment>{' (alt)'}</Fragment>
-									)
-								}
-
 							</span>
+
+							{
+								performer.isAlternate && (
+									<Fragment>{' [alt]'}</Fragment>
+								)
+							}
 
 							{
 								performer.otherRoles.length > 0 && (

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -7,28 +7,32 @@ const JoinedRoles = props => {
 	const { instances } = props;
 
 	return (
-		<span className="fictional-name-text">
+		<Fragment>
 
 			{
 				instances
 					.map((instance, index) =>
 						<Fragment key={index}>
 
-							{
-								instance.uuid
-									? <InstanceLink instance={instance} />
-									: instance.name
-							}
+							<span className="fictional-name-text">
 
-							{
-								instance.qualifier && (
-									<AppendedQualifier qualifier={instance.qualifier} />
-								)
-							}
+								{
+									instance.uuid
+										? <InstanceLink instance={instance} />
+										: instance.name
+								}
+
+								{
+									instance.qualifier && (
+										<AppendedQualifier qualifier={instance.qualifier} />
+									)
+								}
+
+							</span>
 
 							{
 								instance.isAlternate && (
-									<Fragment>{' (alt)'}</Fragment>
+									<Fragment>{' [alt]'}</Fragment>
 								)
 							}
 
@@ -37,7 +41,7 @@ const JoinedRoles = props => {
 					.reduce((accumulator, currentValue) => [accumulator, ' / ', currentValue])
 			}
 
-		</span>
+		</Fragment>
 	);
 
 };


### PR DESCRIPTION
This PR amends how the isAlternate indicator is displayed.

It is used to indicate when the performer of a given role is an alternate and that the role is shared by other performers.

Square brackets should be used to include words within a quote that are not part of the original quote, and in the context of the cast list, the role name can be considered the quote in that it is italicised and is describing a fictional name (or at least the name of a role that appears in a fictional/dramatic context) and the 'alt' aspect of that is something outside of that quote in that it is describing something about it.

In the below screenshots, note how the suffix following Marky's name changes
- from: ' _(alt)_'
- to: ' [alt]'

---

#### Jerusalem at Royal Court Theatre: Jerwood Theatre Downstairs (production) — before
<img width="307" alt="jerusalem-production-before" src="https://github.com/andygout/theatrebase-spa/assets/10484515/4bb0f50e-838a-4b3e-bdcb-179ec8cb08ae">

---

#### Jerusalem at Royal Court Theatre: Jerwood Theatre Downstairs (production) — after
<img width="309" alt="jerusalem-production-after" src="https://github.com/andygout/theatrebase-spa/assets/10484515/011fe0ab-bf40-4e0f-bdd3-87a4b98ee2ab">

---

#### Marky (character) — before
<img width="919" alt="marky-character-before" src="https://github.com/andygout/theatrebase-spa/assets/10484515/15c6be22-d8e9-41f8-a47a-4dfad4b5a60c">

---

#### Marky (character) — after
<img width="915" alt="marky-character-after" src="https://github.com/andygout/theatrebase-spa/assets/10484515/6e61565b-7deb-47a0-824d-5b1a7eded255">