### PR TITLE
Apply Node v18 features

### DIFF
--- a/src/lib/fetch-from-api.js
+++ b/src/lib/fetch-from-api.js
@@ -32,7 +32,7 @@ export default async apiPath => {
 		// If fetch is unsuccessful its error will not have a `status` attribute
 		// but instead have a `code` attribute whose value is 'ECONNREFUSED',
 		// making a 500 response code the most instructive for this scenario.
-		const internalServerError = new Error('Internal Server Error');
+		const internalServerError = new Error('Internal Server Error', { cause: error });
 
 		internalServerError.status = 500;
 


### PR DESCRIPTION
This PR applies some of the features we gain from running on a Node.js version of 18 or above, as described in this blog:

[The features we gain from the Node.js 16 sunset](https://financialtimes.atlassian.net/wiki/spaces/DS/blog/2023/09/06/8135344184/The+features+we+gain+from+the+Node.js+16+sunset) by @rowanmanning

### References:
- [MDN Web Docs: JavaScript — Error: cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)