### PR TITLE
Display material productions of subsequent versions

### DIFF
--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -31,6 +31,7 @@ const Material = props => {
 			characterGroups,
 			originalVersionMaterial,
 			subsequentVersionMaterials,
+			subsequentVersionMaterialProductions,
 			productions,
 			sourcingMaterials,
 			sourcingMaterialProductions,
@@ -190,6 +191,16 @@ const Material = props => {
 						<InstanceFacet labelText='Subsequent versions'>
 
 							<MaterialsList materials={subsequentVersionMaterials} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					subsequentVersionMaterialProductions?.length > 0 && (
+						<InstanceFacet labelText='Productions of subsequent versions'>
+
+							<ProductionsList productions={subsequentVersionMaterialProductions} />
 
 						</InstanceFacet>
 					)


### PR DESCRIPTION
This PR adds logic to display for materials the productions of their subsequent versions, as exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/637.

---

#### A Midsummer Night's Dream (material)
<img width="943" alt="a-midsummer-nights-dream-material" src="https://github.com/andygout/theatrebase-ssr/assets/10484515/375dcf96-c7ee-42b9-b9f6-adeb9b5ffe3a">