### PR TITLE
Display material/production subtitle

### DIFF
--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -7,6 +7,13 @@
 	color: color-variables.$default-text-color;
 }
 
+.subtitle-text {
+	margin: 0 5px 20px 5px;
+	padding-bottom: 0px;
+	font-size: x-large;
+	color: color-variables.$default-text-color;
+}
+
 .fictional-name-text {
 	font-style: italic;
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,11 +1,11 @@
 import { h } from 'preact'; // eslint-disable-line no-unused-vars
 
-import { Footer, Head, Header, InstanceLabel, Navigation, PageTitle } from '.';
+import { Footer, Head, Header, InstanceLabel, Navigation, PageSubtitle, PageTitle } from '.';
 import { CurrentPath } from '../contexts';
 
 const App = props => {
 
-	const { currentPath, documentTitle, pageTitle, model, children } = props;
+	const { currentPath, documentTitle, pageTitle, pageSubtitle, model, children } = props;
 
 	return (
 		<html>
@@ -29,6 +29,12 @@ const App = props => {
 						}
 
 						<PageTitle text={pageTitle} />
+
+						{
+							pageSubtitle && (
+								<PageSubtitle text={pageSubtitle} />
+							)
+						}
 
 						<CurrentPath.Provider value={currentPath}>
 

--- a/src/components/PageSubtitle.jsx
+++ b/src/components/PageSubtitle.jsx
@@ -1,0 +1,15 @@
+import { h } from 'preact'; // eslint-disable-line no-unused-vars
+
+const PageSubtitle = props => {
+
+	const { text } = props;
+
+	return (
+		<h2 className="subtitle-text">
+			{ text }
+		</h2>
+	);
+
+};
+
+export default PageSubtitle;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -31,6 +31,7 @@ import ListWrapper from './ListWrapper';
 import MaterialLinkWithContext from './MaterialLinkWithContext';
 import MaterialsList from './MaterialsList';
 import Navigation from './Navigation';
+import PageSubtitle from './PageSubtitle';
 import PageTitle from './PageTitle';
 import PrependedSurInstance from './PrependedSurInstance';
 import ProducerCredits from './ProducerCredits';
@@ -77,6 +78,7 @@ export {
 	MaterialLinkWithContext,
 	MaterialsList,
 	Navigation,
+	PageSubtitle,
 	PageTitle,
 	PrependedSurInstance,
 	ProducerCredits,

--- a/src/controllers/instances.js
+++ b/src/controllers/instances.js
@@ -19,6 +19,8 @@ export default async (request, response, next) => {
 
 		const title = getInstanceTitle(instance);
 
+		const pageSubtitle = instance.subtitle;
+
 		const differentiatorSuffix = getDifferentiatorSuffix(differentiator);
 
 		const documentTitle = compressTitleComponents([
@@ -36,6 +38,7 @@ export default async (request, response, next) => {
 			currentPath: path,
 			documentTitle,
 			pageTitle,
+			pageSubtitle,
 			[MODEL_TO_PROP_NAME_MAP[model]]: instance
 		};
 

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -18,7 +18,7 @@ import { capitalise } from '../../lib/strings';
 
 const Material = props => {
 
-	const { currentPath, documentTitle, pageTitle, material } = props;
+	const { currentPath, documentTitle, pageTitle, pageSubtitle, material } = props;
 
 	const renderMaterial = material => {
 
@@ -83,6 +83,12 @@ const Material = props => {
 
 									<InstanceLink instance={surMaterial} />
 
+									{
+										surMaterial.subtitle && (
+											<p>{ surMaterial.subtitle }</p>
+										)
+									}
+
 								</InstanceFacet>
 
 								{
@@ -107,6 +113,12 @@ const Material = props => {
 										<InstanceFacet labelText='Material'>
 
 											<InstanceLink instance={subMaterial} />
+
+											{
+												subMaterial.subtitle && (
+													<p>{ subMaterial.subtitle }</p>
+												)
+											}
 
 										</InstanceFacet>
 
@@ -556,7 +568,13 @@ const Material = props => {
 	};
 
 	return (
-		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={material.model}>
+		<App
+			currentPath={currentPath}
+			documentTitle={documentTitle}
+			pageTitle={pageTitle}
+			pageSubtitle={pageSubtitle}
+			model={material.model}
+		>
 
 			{
 				renderMaterial(material)

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -19,7 +19,7 @@ import { formatDate } from '../../lib/format-date';
 
 const Production = props => {
 
-	const { currentPath, documentTitle, pageTitle, production } = props;
+	const { currentPath, documentTitle, pageTitle, pageSubtitle, production } = props;
 
 	const dateFormatOptions = { weekday: 'long', month: 'long' };
 
@@ -127,6 +127,12 @@ const Production = props => {
 
 									<InstanceLink instance={surProduction} />
 
+									{
+										surProduction.subtitle && (
+											<p>{ surProduction.subtitle }</p>
+										)
+									}
+
 								</InstanceFacet>
 
 								{
@@ -151,6 +157,12 @@ const Production = props => {
 										<InstanceFacet labelText='Production'>
 
 											<InstanceLink instance={subProduction} />
+
+											{
+												subProduction.subtitle && (
+													<p>{ subProduction.subtitle }</p>
+												)
+											}
 
 										</InstanceFacet>
 
@@ -347,7 +359,13 @@ const Production = props => {
 	};
 
 	return (
-		<App currentPath={currentPath} documentTitle={documentTitle} pageTitle={pageTitle} model={production.model}>
+		<App
+			currentPath={currentPath}
+			documentTitle={documentTitle}
+			pageTitle={pageTitle}
+			pageSubtitle={pageSubtitle}
+			model={production.model}
+		>
 
 			{
 				renderProduction(production)


### PR DESCRIPTION
This PR adds functionality to be able to display material/production subtitle as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/644.

---

#### Angels in America (material)
<img width="470" alt="angels-in-america" src="https://github.com/andygout/theatrebase-api/assets/10484515/145c22cd-d482-44c5-aefd-15625d39c408">

---

#### Millennium Approaches (material)
<img width="952" alt="millenium-approaches" src="https://github.com/andygout/theatrebase-api/assets/10484515/d38e44a6-5dfa-4c43-8432-b46589386928">

---

#### Tonight At 8.30 (material)
<img width="960" alt="tonight-at-8-30" src="https://github.com/andygout/theatrebase-api/assets/10484515/b1ddb73b-fbcb-4ae9-818f-9038d4e5b1d1">

---

#### We Were Dancing (material)
<img width="337" alt="we-were-dancing" src="https://github.com/andygout/theatrebase-api/assets/10484515/f640d805-6dd0-489e-bfc8-2050646d4e09">

---

#### Henry VI at Courtyard Theatre (production)
<img width="362" alt="henry-vi-part-1-courtyard-theatre" src="https://github.com/andygout/theatrebase-api/assets/10484515/4ae895cc-43d3-46a6-93f6-a7d0f4ff7997">