### PR TITLE
Add search bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "npm": "10.2.1"
   },
   "dependencies": {
+    "@financial-times/o-autocomplete": "^1.9.1",
+    "@financial-times/o-forms": "^9.12.1",
+    "@financial-times/o-utils": "^2.2.1",
     "express": "4.18.1",
     "express-session": "1.17.3",
     "morgan": "1.10.0",

--- a/src/api-router.js
+++ b/src/api-router.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+import { search as searchController } from './controllers';
+
+const router = new Router();
+
+router.get('/search', (request, response, next) =>
+	searchController(request, response, next));
+
+export default router;

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import logger from 'morgan';
 import favicon from 'serve-favicon';
 
 import { errorHandler } from './middleware';
+import apiRouter from './api-router';
 import router from './router';
 
 const app = express();
@@ -15,10 +16,14 @@ app.use(
 	favicon(path.join(__dirname, 'assets', 'favicon.ico')), // Path is relative to `built/main.js`.
 	logger('dev'),
 	session({ secret: 'secret', resave: false, saveUninitialized: true }),
-	express.static('public'),
-	router,
-	errorHandler
+	express.static('public')
 );
+
+app.use('/api', apiRouter);
+
+app.use(router);
+
+app.use(errorHandler);
 
 const port = '3003';
 

--- a/src/client/scripts/index.js
+++ b/src/client/scripts/index.js
@@ -1,0 +1,1 @@
+import './search-bar';

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -1,0 +1,89 @@
+import oAutocomplete from '@financial-times/o-autocomplete';
+import { debounce } from '@financial-times/o-utils';
+
+import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants';
+
+const URL_BASE = 'http://localhost:3003';
+
+async function performFetch (url) {
+
+	const response = await fetch(url, { mode: 'cors' });
+
+	if (response.status !== 200) throw new Error(response.statusText);
+
+	const searchResults = response.json();
+
+	return searchResults;
+
+}
+
+async function getSearchResults (searchTerm) {
+
+	const url = `${URL_BASE}/api/search?searchTerm=${searchTerm}`;
+
+	const searchResults = await performFetch(url);
+
+	return searchResults;
+
+}
+
+function suggestionTemplate (option) {
+
+	return `
+		<div>
+			<span class="o-autocomplete__option-text">${option.name}</span>
+			${' '}
+			<span class="o-autocomplete__option-suffix">${`(${MODEL_TO_DISPLAY_NAME_MAP[option.model]})`}</span>
+		</div>
+	`;
+
+}
+
+function mapOptionToSuggestedValue (option) {
+
+	const { name } = option;
+
+	const suggestedValue = name;
+
+	return suggestedValue;
+
+}
+
+function onConfirm (selectedOption) {
+
+	const { model, uuid } = selectedOption;
+
+	const instancePath = `/${MODEL_TO_ROUTE_MAP[model]}/${uuid}`;
+
+	location.href = instancePath; // eslint-disable-line no-undef
+
+}
+
+async function customSearchResults (searchTerm, populateOptions) {
+
+	if (searchTerm === '') {
+
+		populateOptions([]);
+
+		return;
+
+	}
+
+	const searchResults = await getSearchResults(searchTerm);
+
+	populateOptions(searchResults);
+
+}
+
+document.addEventListener('DOMContentLoaded', function () { // eslint-disable-line no-undef
+
+	const oAutocompleteElement = document.getElementById('autocomplete'); // eslint-disable-line no-undef
+
+	new oAutocomplete(oAutocompleteElement, {
+		suggestionTemplate,
+		mapOptionToSuggestedValue,
+		onConfirm,
+		source: debounce(customSearchResults, 1000)
+	});
+
+});

--- a/src/client/stylesheets/_header.scss
+++ b/src/client/stylesheets/_header.scss
@@ -1,8 +1,15 @@
 @use 'lib/color-variables';
 
 .header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 	background-color: color-variables.$header-background-color;
 	padding: 0 10px;
+}
+
+.header__component {
+	flex: 1;
 }
 
 .header__home-link {

--- a/src/client/stylesheets/_o-autocomplete-modifiers.scss
+++ b/src/client/stylesheets/_o-autocomplete-modifiers.scss
@@ -1,0 +1,44 @@
+@use 'lib/color-variables';
+
+.o-autocomplete {
+	width: 100%;
+}
+
+.o-autocomplete__input {
+	padding-left: 12px !important;
+	border-radius: 6px !important;
+	color: color-variables.$default-text-color;
+}
+
+.o-autocomplete__menu {
+	padding: 8px !important;
+	border-radius: 6px;
+	color: color-variables.$default-text-color !important;
+}
+
+.o-autocomplete__menu-loading-container {
+	top: calc(100% + 2px) !important;
+	border-radius: 6px;
+}
+
+.o-autocomplete__menu--overlay {
+	top: calc(100% + 2px) !important;
+}
+
+.o-autocomplete__option--focused,
+.o-autocomplete__option:hover {
+	background-color: color-variables.$autocomplete-selected-option-background-color !important;
+	border-color: color-variables.$autocomplete-selected-option-background-color !important;
+
+	.o-autocomplete__option-suffix {
+		color: color-variables.$autocomplete-selected-option-color;
+	}
+}
+
+.o-autocomplete__option-text {
+	font-weight: bold;
+}
+
+.o-autocomplete__option-suffix {
+	color: color-variables.$autocomplete-option-suffix-color;
+}

--- a/src/client/stylesheets/_o-forms-modifiers.scss
+++ b/src/client/stylesheets/_o-forms-modifiers.scss
@@ -1,0 +1,3 @@
+.o-forms-input {
+	margin-top: 0 !important;
+}

--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -4,13 +4,13 @@
 	margin: 0;
 	padding: 0;
 	font-family: arial, sans-serif;
-	color: color-variables.$default-text-color;
 	text-decoration: none;
 }
 
 html {
 	height: 100%;
 	text-align: center;
+	color: color-variables.$default-text-color;
 	background-color: color-variables.$html-background-color;
 }
 
@@ -34,6 +34,10 @@ a {
 			cursor: auto;
 		}
 	}
+}
+
+button {
+	cursor: pointer;
 }
 
 .page-container {

--- a/src/client/stylesheets/index.scss
+++ b/src/client/stylesheets/index.scss
@@ -1,3 +1,5 @@
+$system-code: '$$$-no-bizops-system-code-$$$'; // Required for Origami components.
+
 @use 'lib/color-variables';
 
 @use 'normalize';
@@ -9,3 +11,10 @@
 @use 'navigation';
 @use 'page';
 @use 'text';
+
+@use 'o-autocomplete-modifiers';
+@use 'o-forms-modifiers';
+@import '@financial-times/o-autocomplete/main';
+@import '@financial-times/o-forms/main';
+@include oAutocomplete();
+@include oForms();

--- a/src/client/stylesheets/lib/_color-variables.scss
+++ b/src/client/stylesheets/lib/_color-variables.scss
@@ -1,3 +1,6 @@
+$autocomplete-option-suffix-color: #949494;
+$autocomplete-selected-option-background-color: #006699;
+$autocomplete-selected-option-color: #FFFFFF;
 $border-color: #949494;
 $box-shadow-color: #D0D0D0;
 $content-background-color: #FFFFFF;

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -8,12 +8,7 @@ const Head = props => {
 		<head>
 			<title>{`${documentTitle} | TheatreBase`}</title>
 			<link rel="stylesheet" href="/main.css" />
-			<script> </script>
-			{/*
-				Until the above script tags have content,
-				this whitespace will stop the CSS transition
-				from firing on page load.
-			*/}
+			<script src="/main.js" />
 		</head>
 	);
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,7 +5,13 @@ const Header = () => {
 	return (
 		<header className="header">
 
-			<a href='/' className="header__home-link">TheatreBase</a>
+			<a href='/' className="header__component header__home-link">TheatreBase</a>
+
+			<span className="header__component o-forms-input o-forms-input--text">
+				<span id="autocomplete" className="o-autocomplete">
+					<input id="autocomplete-input" type="text" placeholder="Search TheatreBase…" />
+				</span>
+			</span>
 
 		</header>
 	);

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -2,10 +2,12 @@ import errors from './errors';
 import home from './home';
 import instances from './instances';
 import lists from './lists';
+import search from './search';
 
 export {
 	errors,
 	home,
 	instances,
-	lists
+	lists,
+	search
 };

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -1,0 +1,19 @@
+import fetchFromApi from '../lib/fetch-from-api';
+
+export default async (request, response, next) => {
+
+	const { query: { searchTerm } } = request;
+
+	try {
+
+		const searchResults = await fetchFromApi(`/search?searchTerm=${searchTerm}`);
+
+		return response.send(searchResults);
+
+	} catch (error) {
+
+		return next(error);
+
+	}
+
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,10 @@ const serverConfig = {
 
 const clientConfig = {
 	mode: 'none', // i.e. not production or development (see: https://webpack.js.org/configuration/mode).
-	entry: './src/client/stylesheets/index.scss',
+	entry: [
+		'./src/client/scripts/index.js',
+		'./src/client/stylesheets/index.scss'
+	],
 	output: {
 		path: path.join(__dirname, 'public'),
 		filename: 'main.js'


### PR DESCRIPTION
This PR adds a search bar component that consumes from the search endpoint added by this API PR https://github.com/andygout/theatrebase-api/pull/649.

It uses the Origami o-autocomplete component and applies styling overrides to make it stylistically consistent with the search bar implement in https://github.com/andygout/theatrebase-spa/pull/208.

The component is initialised on the page after the DOM content has loaded as per https://origami.ft.com/documentation/tutorials/manual-build/#initialise-all-components-on-the-page.

<img width="1004" alt="ssr" src="https://github.com/andygout/theatrebase-ssr/assets/10484515/8597431f-47f5-4bf9-a02e-eccac36fe3c9">

### Notes:

#### 1.
`$system-code: '$$$-no-bizops-system-code-$$$';` is addd to the top of [`src/client/stylesheets/index.scss`](diff-774a9ff2d96b3a41e7ebd2e2c7ee7ac3abb8bb837efe7746ccf7263be61f7dc4) for reasons explained in the [Origami Build Service — API Reference](https://www.ft.com/__origami/service/build/v3/docs/api#get-v3-bundles-js).

#### 2.
Observed behaviour:
- Focus input
- Type an option that appears in results (dropdown appears)
- Blur input (dropdown menu disappears)
- Focus input: dropdown menu does not reappear owing to this accessible-autocomplete [function](https://github.com/Financial-Times/accessible-autocomplete/blob/master/src/autocomplete.js#L96-L98))
  - Ideally it would reappear as it does in the SPA implementation

#### 3.
The suggestions are not highlighted as they are in the SPA implementation, which is an issue I have sought to address via the following PRs:
- https://github.com/Financial-Times/origami/pull/1516
  - …which depends on these changes https://github.com/Financial-Times/accessible-autocomplete/pull/29 …
    - …which will first require that repo to be able to install its dependencies and build its assets — achieved via https://github.com/Financial-Times/accessible-autocomplete/pull/28

### References:
- [GitHub: Financial-Times/origami/components/o-autocomplete](https://github.com/Financial-Times/origami/tree/main/components/o-autocomplete)
- [Origami Storybook: Components / o-autocomplete - Dynamic Delayed](https://main--655f72ec522e424302dc6201.chromatic.com/?path=/story/o2-core_components-o-autocomplete--dynamic-delayed&globals=backgrounds:!undefined)

### New dependencies:
- [npm: @financial-times/o-autocomplete](https://www.npmjs.com/package/@financial-times/o-autocomplete)
  - …which has a dependency on [npm: @financial-times/accessible-autocomplete]…(https://www.npmjs.com/package/@financial-times/accessible-autocomplete)
    - …which is a fork of [npm: accessible-autocomplete](https://www.npmjs.com/package/accessible-autocomplete) (by alphagov (Government Digital Service))
- [npm: @financial-times/o-forms](https://www.npmjs.com/package/@financial-times/o-forms)
- [npm: @financial-times/o-utils](https://www.npmjs.com/package/@financial-times/o-utils)