### PR TITLE
Use correct fetch mode values

### DIFF
--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -7,7 +7,7 @@ const URL_BASE = 'http://localhost:3003';
 
 async function performFetch (url) {
 
-	const response = await fetch(url, { mode: 'cors' });
+	const response = await fetch(url, { mode: 'same-origin' });
 
 	if (response.status !== 200) throw new Error(response.statusText);
 

--- a/src/lib/fetch-from-api.js
+++ b/src/lib/fetch-from-api.js
@@ -6,7 +6,7 @@ export default async apiPath => {
 
 	try {
 
-		const response = await fetch(apiUrl);
+		const response = await fetch(apiUrl, { mode: 'cors' });
 
 		if (response.status !== 200) {
 


### PR DESCRIPTION
This PR:
- Corrects the `fetch` `mode` value for the request the `search-bar` component makes to the server hosted at the same origin (which then refers the request onto the third-party theatrebase-api endpoint)
- Adds a `fetch` `mode` value for the request the `fetch-from-api` module makes to the third-party theatrebase-api endpoint

### References:
- [MDN: Using the Fetch API - Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
- [Medium: Fetch API: The Ultimate Guide to CORS and `no-cors` by C Y B E R S P H E R E](https://medium.com/@cybersphere/fetch-api-the-ultimate-guide-to-cors-and-no-cors-cbcef88d371e)
- [Stack Overflow: What's the difference between "same-origin" and "no-cors" for JavaScript's Fetch API?](https://stackoverflow.com/questions/35910790/whats-the-difference-between-same-origin-and-no-cors-for-javascripts-fetch)