### PR TITLE
Change project name: TheatreBase -> Dramatis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# theatrebase-ssr [![CircleCI](https://circleci.com/gh/andygout/theatrebase-spa/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/theatrebase-ssr/tree/main)
+# dramatis-ssr [![CircleCI](https://circleci.com/gh/andygout/dramatis-spa/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/dramatis-ssr/tree/main)
 
 Server-side rendered (SSR) application that provides listings for theatrical productions, materials, and associated data.
 
@@ -9,7 +9,7 @@ Server-side rendered (SSR) application that provides listings for theatrical pro
 - Compile code: `$ npm run build`
 
 ## To run locally
-- Ensure an instance of [`theatrebase-api`](https://github.com/andygout/theatrebase-api) is running on `http://localhost:3000`
+- Ensure an instance of [`dramatis-api`](https://github.com/andygout/dramatis-api) is running on `http://localhost:3000`
 - Run server using `$ npm start` and visit homepage at `http://localhost:3003`
 
 ## To run linting checks

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "theatrebase-ssr",
+  "name": "dramatis-ssr",
   "version": "0.0.0",
   "description": "Server-side rendered (SSR) application that provides listings for theatrical productions, materials, and associated data.",
   "author": "https://github.com/andygout",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,7 +6,7 @@ const Footer = () => {
 		<footer className="footer">
 
 			<div className="footer__text footer__text--left">
-				TheatreBase
+				Dramatis
 			</div>
 
 			<div className="footer__text footer__text--right">

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -6,7 +6,7 @@ const Head = props => {
 
 	return (
 		<head>
-			<title>{`${documentTitle} | TheatreBase`}</title>
+			<title>{`${documentTitle} | Dramatis`}</title>
 			<link rel="stylesheet" href="/main.css" />
 			<script src="/main.js" />
 		</head>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,11 +5,11 @@ const Header = () => {
 	return (
 		<header className="header">
 
-			<a href='/' className="header__component header__home-link">TheatreBase</a>
+			<a href='/' className="header__component header__home-link">Dramatis</a>
 
 			<span className="header__component o-forms-input o-forms-input--text">
 				<span id="autocomplete" className="o-autocomplete">
-					<input id="autocomplete-input" type="text" placeholder="Search TheatreBase…" />
+					<input id="autocomplete-input" type="text" placeholder="Search Dramatis…" />
 				</span>
 			</span>
 


### PR DESCRIPTION
This PR changes the project name from **TheatreBase** to **Dramatis**.

Dramatis is Latin for 'of or relating to the drama' and is most commonly known in the context of 'dramatis personae' (literally 'persons of the drama').

It was also the name of an English synth-pop band from the early 1980s: https://en.wikipedia.org/wiki/Dramatis.

It is also a shorter title, meaning (as well as other places that might be an advantage) more of the word will appear in the browser tab when many tabs are open (or the browser window is narrow) and less of the document title text can display.

An obvious idea for a logo would be to incorporate the tragedy and comedy masks — the symmetry of the 'a's (i.e. the third and fifth characters) could be used for this purpose.

TheatreBase also has some drawbacks:
- theatre/theater has different spellings in the UK and US (which may result in needing to acquire more domain names to account for attempts to visit URLs of both spellings)
- its initialism, TB, is an abbreviation of tuberculosis
- the name was something of a play of it sounding similar to 'database' (i.e. a database of theatrebase), though this is not particularly obvious and it reads more of it being a base for theatre, and it's not entirely clear what that is

---

#### Before
<img width="1039" alt="before" src="https://github.com/andygout/dramatis-spa/assets/10484515/833242cc-199f-4815-8e9b-a8ff09e6255e">

---

#### After
<img width="1039" alt="after" src="https://github.com/andygout/dramatis-spa/assets/10484515/b7b6e003-9350-4b51-8522-30a1d79b3584">