### PR TITLE
Display production reviews

### DIFF
--- a/src/components/AppendedDate.jsx
+++ b/src/components/AppendedDate.jsx
@@ -1,0 +1,17 @@
+import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+
+import { formatDate } from '../lib/format-date';
+
+const AppendedDate = props => {
+
+	const { date } = props;
+
+	return (
+		<Fragment>
+			{` (${formatDate(date)})`}
+		</Fragment>
+	);
+
+};
+
+export default AppendedDate;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 import App from './App';
 import AppendedCoEntities from './AppendedCoEntities';
+import AppendedDate from './AppendedDate';
 import AppendedDepictions from './AppendedDepictions';
 import AppendedEmployerCompany from './AppendedEmployerCompany';
 import AppendedEntities from './AppendedEntities';
@@ -47,6 +48,7 @@ import WritingEntities from './WritingEntities';
 export {
 	App,
 	AppendedCoEntities,
+	AppendedDate,
 	AppendedDepictions,
 	AppendedEmployerCompany,
 	AppendedEntities,

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -3,6 +3,7 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 import {
 	App,
 	AppendedCoEntities,
+	AppendedDate,
 	AppendedEntities,
 	AppendedMembers,
 	CommaSeparatedMaterials,
@@ -14,6 +15,7 @@ import {
 	ListWrapper,
 	MaterialsList,
 	ProducerProductionsList,
+	ProductionLinkWithContext,
 	ProductionsList
 } from '../../components';
 
@@ -34,6 +36,7 @@ const Company = props => {
 		producerProductions,
 		creativeProductions,
 		crewProductions,
+		reviewPublicationProductions,
 		awards,
 		subsequentVersionMaterialAwards,
 		sourcingMaterialAwards,
@@ -148,6 +151,46 @@ const Company = props => {
 					<InstanceFacet labelText='Productions as crew member'>
 
 						<CrewProductionsList productions={crewProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				reviewPublicationProductions?.length > 0 && (
+					<InstanceFacet labelText='Reviewed productions'>
+
+						<ListWrapper>
+
+							{
+								reviewPublicationProductions.map((reviewPublicationProduction, index) =>
+									<li key={index}>
+
+										<ProductionLinkWithContext production={reviewPublicationProduction} />
+
+										{' — reviewed by '}
+
+										<InstanceLink instance={reviewPublicationProduction.review.critic} />
+
+										{
+											(reviewPublicationProduction.review.date) && (
+												<AppendedDate date={reviewPublicationProduction.review.date} />
+											)
+										}
+
+										{': '}
+
+										<a
+											href={reviewPublicationProduction.review.url}
+											target="_blank"
+											rel="noopener noreferrer"
+										>{'link'}</a>
+
+									</li>
+								)
+							}
+
+						</ListWrapper>
 
 					</InstanceFacet>
 				)

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -3,6 +3,7 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 import {
 	App,
 	AppendedCoEntities,
+	AppendedDate,
 	AppendedEmployerCompany,
 	AppendedEntities,
 	AppendedRoles,
@@ -37,6 +38,7 @@ const Person = props => {
 		castMemberProductions,
 		creativeProductions,
 		crewProductions,
+		reviewCriticProductions,
 		awards,
 		subsequentVersionMaterialAwards,
 		sourcingMaterialAwards,
@@ -179,6 +181,46 @@ const Person = props => {
 					<InstanceFacet labelText='Productions as crew member'>
 
 						<CrewProductionsList productions={crewProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				reviewCriticProductions?.length > 0 && (
+					<InstanceFacet labelText='Reviewed productions'>
+
+						<ListWrapper>
+
+							{
+								reviewCriticProductions.map((reviewCriticProduction, index) =>
+									<li key={index}>
+
+										<ProductionLinkWithContext production={reviewCriticProduction} />
+
+										{' — reviewed for '}
+
+										<InstanceLink instance={reviewCriticProduction.review.publication} />
+
+										{
+											(reviewCriticProduction.review.date) && (
+												<AppendedDate date={reviewCriticProduction.review.date} />
+											)
+										}
+
+										{': '}
+
+										<a
+											href={reviewCriticProduction.review.url}
+											target="_blank"
+											rel="noopener noreferrer"
+										>{'link'}</a>
+
+									</li>
+								)
+							}
+
+						</ListWrapper>
 
 					</InstanceFacet>
 				)

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -2,6 +2,7 @@ import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
 
 import {
 	App,
+	AppendedDate,
 	AppendedRoles,
 	CommaSeparatedMaterials,
 	CommaSeparatedProductions,
@@ -39,6 +40,7 @@ const Production = props => {
 			cast,
 			creativeCredits,
 			crewCredits,
+			reviews,
 			awards
 		} = production;
 
@@ -231,6 +233,46 @@ const Production = props => {
 						<InstanceFacet labelText='Crew'>
 
 							<ProductionTeamCreditsList credits={crewCredits} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					reviews?.length > 0 && (
+						<InstanceFacet labelText='Reviews'>
+
+							<ListWrapper>
+
+								{
+									reviews.map((review, index) =>
+										<li key={index}>
+
+											<InstanceLink instance={review.critic} />
+
+											{', '}
+
+											<InstanceLink instance={review.publication} />
+
+											{
+												(review.date) && (
+													<AppendedDate date={review.date} />
+												)
+											}
+
+											{': '}
+
+											<a
+												href={review.url}
+												target="_blank"
+												rel="noopener noreferrer"
+											>{'link'}</a>
+
+										</li>
+									)
+								}
+
+							</ListWrapper>
 
 						</InstanceFacet>
 					)


### PR DESCRIPTION
Display production reviews introduced by this API PR: https://github.com/andygout/dramatis-api/pull/658.

---

####  Long Day's Journey Into Night at the Wyndham's Theatre (production)
<img width="529" alt="long-days-journey-into-night-wyndhams-production" src="https://github.com/andygout/dramatis-api/assets/10484515/eacbf129-eccc-4114-82e9-08d330e91526">

---

#### Financial Times (company)
<img width="864" alt="financial-times-company" src="https://github.com/andygout/dramatis-api/assets/10484515/07fa083f-998b-4ec7-9c23-db8c35cc54f4">

---

#### Sarah Hemming (person)
<img width="859" alt="sarah-hemming-person" src="https://github.com/andygout/dramatis-api/assets/10484515/5aa9d406-b0d6-4736-be51-558fa8d11eaa">