### PR TITLE
Apply autocomplete option highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm": "10.2.1"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "^1.9.1",
+    "@financial-times/o-autocomplete": "^1.10.0",
     "@financial-times/o-forms": "^9.12.1",
     "@financial-times/o-utils": "^2.2.1",
     "express": "4.19.2",

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -27,11 +27,57 @@ async function getSearchResults (searchTerm) {
 
 }
 
-function suggestionTemplate (option) {
+function highlightSuggestion (suggestion, query) {
+
+	const result = suggestion.split('');
+
+	const matchIndex = suggestion.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
+
+	return result.map((character, index) => {
+
+		let shouldHighlight = false;
+
+		const hasMatched = matchIndex > -1;
+
+		const characterIsWithinMatch =
+			index >= matchIndex &&
+			index <= matchIndex + query.length - 1;
+
+		if (hasMatched && characterIsWithinMatch) {
+
+			shouldHighlight = true;
+
+		}
+
+		return [character, shouldHighlight];
+
+	});
+
+}
+
+function suggestionTemplate (option, query) {
+
+	const characters = highlightSuggestion(option.name, query || option.name);
+
+	let highlightedOptionName = '';
+
+	for (const [character, shoudHighlight] of characters) {
+
+		if (shoudHighlight) {
+
+			highlightedOptionName += `<span class="o-autocomplete__option--highlight">${character}</span>`;
+
+		} else {
+
+			highlightedOptionName += `${character}`;
+
+		}
+
+	}
 
 	return `
 		<div>
-			<span class="o-autocomplete__option-text">${option.name}</span>
+			<span">${highlightedOptionName}</span>
 			${' '}
 			<span class="o-autocomplete__option-suffix">${`(${MODEL_TO_DISPLAY_NAME_MAP[option.model]})`}</span>
 		</div>

--- a/src/client/stylesheets/_o-autocomplete-modifiers.scss
+++ b/src/client/stylesheets/_o-autocomplete-modifiers.scss
@@ -35,10 +35,6 @@
 	}
 }
 
-.o-autocomplete__option-text {
-	font-weight: bold;
-}
-
 .o-autocomplete__option-suffix {
 	color: color-variables.$autocomplete-option-suffix-color;
 }


### PR DESCRIPTION
This PR employs the changes included in [v1.10.0](https://github.com/Financial-Times/origami/releases/tag/o-autocomplete-v1.10.0) of `@financial-times/o-autocomplete`: https://github.com/Financial-Times/origami/pull/1516.

The changes are visual ones and mean that only the matched text of an option will be bold rather than its whole name, making the styling logic consistent with the search bar for:
- dramatis-cms: https://github.com/andygout/dramatis-cms/pull/211
- dramatis-spa: https://github.com/andygout/dramatis-spa/pull/208 

#### Before
<img width="1004" alt="before" src="https://github.com/andygout/dramatis-ssr/assets/10484515/d309cd10-c281-4b1c-bd67-424c36fd46cb">

---

#### After
<img width="1004" alt="after" src="https://github.com/andygout/dramatis-ssr/assets/10484515/5d64e154-bf2a-409b-a0a1-678754883f6c">