### PR TITLE
Preserve output for both watched paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "rollup --config",
     "watch": "rollup --config --watch",
-    "start": "npm run watch & node --watch-path=built --watch-path=public --watch-preserve-output --require source-map-support/register built/main.js"
+    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",


### PR DESCRIPTION
As per the **Functionality checks** section in the description of this PR https://github.com/andygout/dramatis-ssr/pull/252, rebuilds triggered by changes in the client-side code that gets transpiled into the `public` directory cause the output to be cleared.

This PR adds a `--watch-preserve-output` flag for each of the `--watch-path` commands so that the output is preserved regardless of what code is changed.