### PR TITLE
Use Node.js-native source maps enablement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "rollup --config",
     "watch": "rollup --config --watch",
-    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --require source-map-support/register built/main.js"
+    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js"
   },
   "pre-commit": [
     "lint-check",
@@ -36,8 +36,7 @@
     "morgan": "1.10.0",
     "preact": "10.22.0",
     "preact-render-to-string": "6.5.3",
-    "serve-favicon": "2.5.0",
-    "source-map-support": "0.5.21"
+    "serve-favicon": "2.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "26.0.1",


### PR DESCRIPTION
This PR applies the Node.js-native source maps enablement (by applying the `--enable-source-maps` flag), which, as per the [documentation](https://nodejs.org/api/cli.html#--enable-source-maps), has not been experimental since v15.11.0 and v14.18.0.

This change also means that the `source-map-support` dependency is no longer required and can be removed.

### References:
- [Node.js v22.8.0 | Command-line API: `--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps)
- [Medium: Source maps in Node.js](https://nodejs.medium.com/source-maps-in-node-js-482872b56116) by Node.js (contributed by Benjamin Coe)