### PR TITLE
Use JSX automatic import transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "morgan": "1.10.0",
     "preact": "10.22.0",
     "preact-render-to-string": "6.5.3",
+    "react": "npm:@preact/compat",
     "serve-favicon": "2.5.0"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,13 +20,15 @@ const serverBundle = {
 		'node:http',
 		'preact',
 		'preact-render-to-string',
-		'preact/hooks'
+		'preact/hooks',
+		'react/jsx-runtime'
 	],
 	watch: {
 		clearScreen: false
 	},
 	plugins: [
 		esbuild({
+			jsx: 'automatic',
 			jsxFactory: 'h',
 			jsxFragment: 'Fragment'
 		}),

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { Footer, Head, Header, InstanceLabel, Navigation, PageSubtitle, PageTitle } from './index.js';
 import { CurrentPath } from '../contexts/index.js';
 

--- a/src/components/AppendedCoEntities.jsx
+++ b/src/components/AppendedCoEntities.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { Entities } from './index.js';
 

--- a/src/components/AppendedDate.jsx
+++ b/src/components/AppendedDate.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { formatDate } from '../lib/format-date.js';
 

--- a/src/components/AppendedDepictions.jsx
+++ b/src/components/AppendedDepictions.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 const AppendedDepictions = props => {
 

--- a/src/components/AppendedEmployerCompany.jsx
+++ b/src/components/AppendedEmployerCompany.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
 

--- a/src/components/AppendedEntities.jsx
+++ b/src/components/AppendedEntities.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { Entities } from './index.js';
 

--- a/src/components/AppendedFormatAndYear.jsx
+++ b/src/components/AppendedFormatAndYear.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 const AppendedFormatAndYear = props => {
 

--- a/src/components/AppendedMembers.jsx
+++ b/src/components/AppendedMembers.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { CommaSeparatedInstanceLinks } from './index.js';
 

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { InstanceLink, JoinedRoles } from './index.js';
 

--- a/src/components/AppendedProductionDates.jsx
+++ b/src/components/AppendedProductionDates.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { formatDate } from '../lib/format-date.js';
 

--- a/src/components/AppendedProductionTeamCredits.jsx
+++ b/src/components/AppendedProductionTeamCredits.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedCoEntities, AppendedEmployerCompany, AppendedMembers } from './index.js';
 

--- a/src/components/AppendedQualifier.jsx
+++ b/src/components/AppendedQualifier.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 const AppendedQualifier = props => {
 

--- a/src/components/AppendedRoles.jsx
+++ b/src/components/AppendedRoles.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { JoinedRoles } from './index.js';
 

--- a/src/components/AppendedVenue.jsx
+++ b/src/components/AppendedVenue.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { VenueLinkWithContext } from './index.js';
 

--- a/src/components/CharactersList.jsx
+++ b/src/components/CharactersList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { AppendedQualifier, InstanceLink, ListWrapper } from './index.js';
 
 const CharactersList = props => {

--- a/src/components/CommaSeparatedInstanceLinks.jsx
+++ b/src/components/CommaSeparatedInstanceLinks.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { InstanceLink } from './index.js';
 

--- a/src/components/CommaSeparatedMaterials.jsx
+++ b/src/components/CommaSeparatedMaterials.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { MaterialLinkWithContext } from './index.js';
 

--- a/src/components/CommaSeparatedProductions.jsx
+++ b/src/components/CommaSeparatedProductions.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { ProductionLinkWithContext } from './index.js';
 

--- a/src/components/CreativeProductionsList.jsx
+++ b/src/components/CreativeProductionsList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 
 const CreativeProductionsList = props => {

--- a/src/components/CrewProductionsList.jsx
+++ b/src/components/CrewProductionsList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 
 const CrewProductionsList = props => {

--- a/src/components/Entities.jsx
+++ b/src/components/Entities.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedMembers, InstanceLink } from './index.js';
 

--- a/src/components/FestivalLinkWithContext.jsx
+++ b/src/components/FestivalLinkWithContext.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const Footer = () => {
 
 	return (

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const Head = props => {
 
 	const { documentTitle } = props;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const Header = () => {
 
 	return (

--- a/src/components/InstanceFacet.jsx
+++ b/src/components/InstanceFacet.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const InstanceFacet = props => {
 
 	const { labelText, children } = props;

--- a/src/components/InstanceLabel.jsx
+++ b/src/components/InstanceLabel.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { MODEL_TO_DISPLAY_NAME_MAP } from '../utils/constants.js';
 
 const InstanceLabel = props => {

--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,4 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
 import { useContext } from 'preact/hooks';
 
 import { CurrentPath } from '../contexts/index.js';

--- a/src/components/InstanceLinksList.jsx
+++ b/src/components/InstanceLinksList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { InstanceLink, ListWrapper } from './index.js';
 
 const InstanceLinksList = props => {

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedQualifier, InstanceLink } from './index.js';
 

--- a/src/components/ListWrapper.jsx
+++ b/src/components/ListWrapper.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const ListWrapper = props => {
 
 	const { children } = props;

--- a/src/components/MaterialLinkWithContext.jsx
+++ b/src/components/MaterialLinkWithContext.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
 

--- a/src/components/MaterialsList.jsx
+++ b/src/components/MaterialsList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { ListWrapper, MaterialLinkWithContext } from './index.js';
 
 const MaterialsList = props => {

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const Navigation = () => {
 
 	return (

--- a/src/components/PageSubtitle.jsx
+++ b/src/components/PageSubtitle.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const PageSubtitle = props => {
 
 	const { text } = props;

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 const PageTitle = props => {
 
 	const { text } = props;

--- a/src/components/PrependedSurInstance.jsx
+++ b/src/components/PrependedSurInstance.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { InstanceLink } from './index.js';
 

--- a/src/components/ProducerCredits.jsx
+++ b/src/components/ProducerCredits.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { ProducerEntities } from './index.js';
 import { capitalise } from '../lib/strings.js';

--- a/src/components/ProducerEntities.jsx
+++ b/src/components/ProducerEntities.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
 

--- a/src/components/ProducerProductionsList.jsx
+++ b/src/components/ProducerProductionsList.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { ProducerCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 

--- a/src/components/ProductionLinkWithContext.jsx
+++ b/src/components/ProductionLinkWithContext.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedProductionDates, AppendedVenue, InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/components/ProductionTeamCreditsList.jsx
+++ b/src/components/ProductionTeamCreditsList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { AppendedEntities, ListWrapper } from './index.js';
 
 const ProductionTeamCreditsList = props => {

--- a/src/components/ProductionsList.jsx
+++ b/src/components/ProductionsList.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { ListWrapper, ProductionLinkWithContext } from './index.js';
 
 const ProductionsList = props => {

--- a/src/components/VenueLinkWithContext.jsx
+++ b/src/components/VenueLinkWithContext.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/components/WritingCredits.jsx
+++ b/src/components/WritingCredits.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { WritingEntities } from './index.js';
 import { capitalise } from '../lib/strings.js';

--- a/src/components/WritingEntities.jsx
+++ b/src/components/WritingEntities.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
 

--- a/src/controllers/helpers/render-component-to-string.jsx
+++ b/src/controllers/helpers/render-component-to-string.jsx
@@ -1,4 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string';
 
 const renderComponentToString = (PageComponent, props) => {

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App } from '../components/index.js';
 
 const ErrorPage = props => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App } from '../components/index.js';
 
 const Home = props => {

--- a/src/pages/instances/Award.jsx
+++ b/src/pages/instances/Award.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceFacet, InstanceLinksList } from '../../components/index.js';
 
 const Award = props => {

--- a/src/pages/instances/AwardCeremony.jsx
+++ b/src/pages/instances/AwardCeremony.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import {
 	App,

--- a/src/pages/instances/Character.jsx
+++ b/src/pages/instances/Character.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import {
 	App,
 	AppendedDepictions,

--- a/src/pages/instances/Company.jsx
+++ b/src/pages/instances/Company.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import {
 	App,

--- a/src/pages/instances/Festival.jsx
+++ b/src/pages/instances/Festival.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceFacet, InstanceLink, ProductionsList } from '../../components/index.js';
 
 const Festival = props => {

--- a/src/pages/instances/FestivalSeries.jsx
+++ b/src/pages/instances/FestivalSeries.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceFacet, InstanceLinksList } from '../../components/index.js';
 
 const FestivalSeries = props => {

--- a/src/pages/instances/Material.jsx
+++ b/src/pages/instances/Material.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import {
 	App,

--- a/src/pages/instances/Person.jsx
+++ b/src/pages/instances/Person.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import {
 	App,

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import {
 	App,

--- a/src/pages/instances/Season.jsx
+++ b/src/pages/instances/Season.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceFacet, ProductionsList } from '../../components/index.js';
 
 const Season = props => {

--- a/src/pages/instances/Venue.jsx
+++ b/src/pages/instances/Venue.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceFacet, InstanceLink, InstanceLinksList, ProductionsList } from '../../components/index.js';
 
 const Venue = props => {

--- a/src/pages/lists/AwardCeremonies.jsx
+++ b/src/pages/lists/AwardCeremonies.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { App, InstanceLink, ListWrapper } from '../../components/index.js';
 

--- a/src/pages/lists/Awards.jsx
+++ b/src/pages/lists/Awards.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const Awards = props => {

--- a/src/pages/lists/Characters.jsx
+++ b/src/pages/lists/Characters.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const Characters = props => {

--- a/src/pages/lists/Companies.jsx
+++ b/src/pages/lists/Companies.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const Companies = props => {

--- a/src/pages/lists/FestivalSerieses.jsx
+++ b/src/pages/lists/FestivalSerieses.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const FestivalSerieses = props => {

--- a/src/pages/lists/Festivals.jsx
+++ b/src/pages/lists/Festivals.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { App, InstanceLink, ListWrapper } from '../../components/index.js';
 

--- a/src/pages/lists/Materials.jsx
+++ b/src/pages/lists/Materials.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, MaterialsList } from '../../components/index.js';
 
 const Materials = props => {

--- a/src/pages/lists/People.jsx
+++ b/src/pages/lists/People.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const People = props => {

--- a/src/pages/lists/Productions.jsx
+++ b/src/pages/lists/Productions.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, ProductionsList } from '../../components/index.js';
 
 const Productions = props => {

--- a/src/pages/lists/Seasons.jsx
+++ b/src/pages/lists/Seasons.jsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'; // eslint-disable-line no-unused-vars
-
 import { App, InstanceLinksList } from '../../components/index.js';
 
 const Seasons = props => {

--- a/src/pages/lists/Venues.jsx
+++ b/src/pages/lists/Venues.jsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact'; // eslint-disable-line no-unused-vars
+import { Fragment } from 'preact';
 
 import { App, InstanceLink, ListWrapper } from '../../components/index.js';
 


### PR DESCRIPTION
When switching to Rollup.js in PR https://github.com/andygout/dramatis-ssr/pull/252, this [DEV Community article](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) mentioned that it is possible to:
> [eliminate] the need for a global React import in each file that uses JSX

This is achieved in the rollup.config.js file by modifying the value of the `presets` property in the object passed as an argument to the function provided by `@rollup/plugin-babel` (and some equivalent changes for the server bundle).

### References:
- [DEV Community: Setup rollup for React Library project - 2024](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) by Vivek Kumar
  - > **What is runtime: "automatic ?**
     > The "automatic" runtime in Babel refers to the new JSX transform introduced in Babel 17. This transform changes how JSX is compiled, and it eliminates the need for a global React import in each file that uses JSX.
     > With the introduction of the automatic runtime in Babel 17, the need for the explicit React import is eliminated.
- [React Blog: Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
- [npm: rollup-plugin-esbuild](https://www.npmjs.com/package/rollup-plugin-esbuild#usage)
  - Demonstrates the `jsx` property
- [GitHub: evanw / esbuild — Issue: Support jsx automatic runtime — comment from evanw](https://github.com/evanw/esbuild/issues/334)
- [esbuild: Content Types — Auto-import for JSX](https://esbuild.github.io/content-types/#auto-import-for-jsx)
  - Demonstrates that `'automatic'` is a valid argument for the `jsx` property
- [Preact Guide: Getting Started — Aliasing React to Preact: Aliasing in Node](https://preactjs.com/guide/v10/getting-started#aliasing-in-node)
  - Aliasing in Rollup did not work, which I assume is because it is only in the output transpiled code that `react/jsx-runtime` is present, i.e. it is not in the pre-transpiled code and therefore cannot be handled as part of Rollup's transpilation