### PR TITLE
Remove esbuild object argument properties (jsxFactory + jsxFragment)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,9 +28,7 @@ const serverBundle = {
 	},
 	plugins: [
 		esbuild({
-			jsx: 'automatic',
-			jsxFactory: 'h',
-			jsxFragment: 'Fragment'
+			jsx: 'automatic'
 		}),
 		copy({
 			targets: [


### PR DESCRIPTION
The changes made in PR https://github.com/andygout/dramatis-ssr/pull/258 mean that it is no longer necessary to configure the JSX factory and JSX fragment settings (perhaps because the package.json's `react` dependency is pointing to `npm:@preact/compat` [here](https://github.com/andygout/dramatis-ssr/blob/8062bd7c8a8eb0b1c9a53f54e3c5cd1444fe5423/package.json#L39)).

### References:
- [GitHub: egoist/rollup-plugin-esbuild — Usage](https://github.com/egoist/rollup-plugin-esbuild#usage)
- [esbuild: Content Types — Using JSX without React](https://esbuild.github.io/content-types/#using-jsx-without-react)
  - > If you're using JSX with a library other than React (such as Preact), you'll likely need to configure the JSX factory and JSX fragment settings since they default to React.createElement and React.Fragment respectively:
    > `esbuild app.jsx --jsx-factory=h --jsx-fragment=Fragment`