### PR TITLE
Resolve Rollup 'Circular dependencies' warning

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,10 @@
-import { Footer, Head, Header, InstanceLabel, Navigation, PageSubtitle, PageTitle } from './index.js';
+import Footer from './Footer.jsx';
+import Head from './Head.jsx';
+import Header from './Header.jsx';
+import InstanceLabel from './InstanceLabel.jsx';
+import Navigation from './Navigation.jsx';
+import PageSubtitle from './PageSubtitle.jsx';
+import PageTitle from './PageTitle.jsx';
 import { CurrentPath } from '../contexts/index.js';
 
 const App = props => {

--- a/src/components/AppendedCoEntities.jsx
+++ b/src/components/AppendedCoEntities.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { Entities } from './index.js';
+import Entities from './Entities.jsx';
 
 const AppendedCoEntities = props => {
 

--- a/src/components/AppendedEmployerCompany.jsx
+++ b/src/components/AppendedEmployerCompany.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const AppendedEmployerCompany = props => {
 

--- a/src/components/AppendedEntities.jsx
+++ b/src/components/AppendedEntities.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { Entities } from './index.js';
+import Entities from './Entities.jsx';
 
 const AppendedEntities = props => {
 

--- a/src/components/AppendedMembers.jsx
+++ b/src/components/AppendedMembers.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { CommaSeparatedInstanceLinks } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
 
 const AppendedMembers = props => {
 

--- a/src/components/AppendedPerformers.jsx
+++ b/src/components/AppendedPerformers.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { InstanceLink, JoinedRoles } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import JoinedRoles from './JoinedRoles.jsx';
 
 const AppendedPerformers = props => {
 

--- a/src/components/AppendedProductionTeamCredits.jsx
+++ b/src/components/AppendedProductionTeamCredits.jsx
@@ -1,6 +1,8 @@
 import { Fragment } from 'preact';
 
-import { AppendedCoEntities, AppendedEmployerCompany, AppendedMembers } from './index.js';
+import AppendedCoEntities from './AppendedCoEntities.jsx';
+import AppendedEmployerCompany from './AppendedEmployerCompany.jsx';
+import AppendedMembers from './AppendedMembers.jsx';
 
 const AppendedProductionTeamCredits = props => {
 

--- a/src/components/AppendedRoles.jsx
+++ b/src/components/AppendedRoles.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { JoinedRoles } from './index.js';
+import JoinedRoles from './JoinedRoles.jsx';
 
 const AppendedRoles = props => {
 

--- a/src/components/AppendedVenue.jsx
+++ b/src/components/AppendedVenue.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { VenueLinkWithContext } from './index.js';
+import VenueLinkWithContext from './VenueLinkWithContext.jsx';
 
 const AppendedVenue = props => {
 

--- a/src/components/CharactersList.jsx
+++ b/src/components/CharactersList.jsx
@@ -1,4 +1,6 @@
-import { AppendedQualifier, InstanceLink, ListWrapper } from './index.js';
+import AppendedQualifier from './AppendedQualifier.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CharactersList = props => {
 

--- a/src/components/CommaSeparatedInstanceLinks.jsx
+++ b/src/components/CommaSeparatedInstanceLinks.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { InstanceLink } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
 
 const CommaSeparatedInstanceLinks = props => {
 

--- a/src/components/CommaSeparatedMaterials.jsx
+++ b/src/components/CommaSeparatedMaterials.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { MaterialLinkWithContext } from './index.js';
+import MaterialLinkWithContext from './MaterialLinkWithContext.jsx';
 
 const CommaSeparatedMaterials = props => {
 

--- a/src/components/CommaSeparatedProductions.jsx
+++ b/src/components/CommaSeparatedProductions.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { ProductionLinkWithContext } from './index.js';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const CommaSeparatedProductions = props => {
 

--- a/src/components/CreativeProductionsList.jsx
+++ b/src/components/CreativeProductionsList.jsx
@@ -1,4 +1,6 @@
-import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CreativeProductionsList = props => {
 

--- a/src/components/CrewProductionsList.jsx
+++ b/src/components/CrewProductionsList.jsx
@@ -1,4 +1,6 @@
-import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CrewProductionsList = props => {
 

--- a/src/components/Entities.jsx
+++ b/src/components/Entities.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { AppendedMembers, InstanceLink } from './index.js';
+import AppendedMembers from './AppendedMembers.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const Entities = props => {
 

--- a/src/components/FestivalLinkWithContext.jsx
+++ b/src/components/FestivalLinkWithContext.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { InstanceLink, PrependedSurInstance } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const FestivalLinkWithContext = props => {
 

--- a/src/components/InstanceLinksList.jsx
+++ b/src/components/InstanceLinksList.jsx
@@ -1,4 +1,5 @@
-import { InstanceLink, ListWrapper } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const InstanceLinksList = props => {
 

--- a/src/components/JoinedRoles.jsx
+++ b/src/components/JoinedRoles.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { AppendedQualifier, InstanceLink } from './index.js';
+import AppendedQualifier from './AppendedQualifier.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const JoinedRoles = props => {
 

--- a/src/components/MaterialLinkWithContext.jsx
+++ b/src/components/MaterialLinkWithContext.jsx
@@ -1,6 +1,9 @@
 import { Fragment } from 'preact';
 
-import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
+import AppendedFormatAndYear from './AppendedFormatAndYear.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
+import WritingCredits from './WritingCredits.jsx';
 
 const MaterialLinkWithContext = props => {
 

--- a/src/components/MaterialsList.jsx
+++ b/src/components/MaterialsList.jsx
@@ -1,4 +1,5 @@
-import { ListWrapper, MaterialLinkWithContext } from './index.js';
+import ListWrapper from './ListWrapper.jsx';
+import MaterialLinkWithContext from './MaterialLinkWithContext.jsx';
 
 const MaterialsList = props => {
 

--- a/src/components/PrependedSurInstance.jsx
+++ b/src/components/PrependedSurInstance.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { InstanceLink } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
 
 const PrependedSurInstance = props => {
 

--- a/src/components/ProducerCredits.jsx
+++ b/src/components/ProducerCredits.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'preact';
 
-import { ProducerEntities } from './index.js';
 import { capitalise } from '../lib/strings.js';
+import ProducerEntities from './ProducerEntities.jsx';
 
 const ProducerCredits = props => {
 

--- a/src/components/ProducerEntities.jsx
+++ b/src/components/ProducerEntities.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const ProducerEntities = props => {
 

--- a/src/components/ProducerProductionsList.jsx
+++ b/src/components/ProducerProductionsList.jsx
@@ -1,6 +1,8 @@
 import { Fragment } from 'preact';
 
-import { ProducerCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import ProducerCredits from './ProducerCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const ProducerProductionsList = props => {
 

--- a/src/components/ProductionLinkWithContext.jsx
+++ b/src/components/ProductionLinkWithContext.jsx
@@ -1,6 +1,9 @@
 import { Fragment } from 'preact';
 
-import { AppendedProductionDates, AppendedVenue, InstanceLink, PrependedSurInstance } from './index.js';
+import AppendedProductionDates from './AppendedProductionDates.jsx';
+import AppendedVenue from './AppendedVenue.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const ProductionLinkWithContext = props => {
 

--- a/src/components/ProductionTeamCreditsList.jsx
+++ b/src/components/ProductionTeamCreditsList.jsx
@@ -1,4 +1,5 @@
-import { AppendedEntities, ListWrapper } from './index.js';
+import AppendedEntities from './AppendedEntities.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const ProductionTeamCreditsList = props => {
 

--- a/src/components/ProductionsList.jsx
+++ b/src/components/ProductionsList.jsx
@@ -1,4 +1,5 @@
-import { ListWrapper, ProductionLinkWithContext } from './index.js';
+import ListWrapper from './ListWrapper.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const ProductionsList = props => {
 

--- a/src/components/VenueLinkWithContext.jsx
+++ b/src/components/VenueLinkWithContext.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'preact';
 
-import { InstanceLink, PrependedSurInstance } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const VenueLinkWithContext = props => {
 

--- a/src/components/WritingCredits.jsx
+++ b/src/components/WritingCredits.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'preact';
 
-import { WritingEntities } from './index.js';
 import { capitalise } from '../lib/strings.js';
+import WritingEntities from './WritingEntities.jsx';
 
 const WritingCredits = props => {
 

--- a/src/components/WritingEntities.jsx
+++ b/src/components/WritingEntities.jsx
@@ -1,6 +1,9 @@
 import { Fragment } from 'preact';
 
-import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
+import AppendedFormatAndYear from './AppendedFormatAndYear.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
+import WritingCredits from './WritingCredits.jsx';
 
 const WritingEntities = props => {
 


### PR DESCRIPTION
The `npm run build` command (which triggers the Rollup build task) currently outputs the below warning:

> src/app.js → built/main.js...
> (!) Circular dependencies
> src/components/index.js -> src/components/App.jsx -> src/components/index.js
> src/components/index.js -> src/components/AppendedCoEntities.jsx -> src/components/index.js
> src/components/index.js -> src/components/AppendedEmployerCompany.jsx -> src/components/index.js
> ...and 28 more
> created built/main.js in 535ms

This PR resolves the majority of those circular dependencies.

One circular dependency remains:
> src/app.js → built/main.js...
> (!) Circular dependency
> src/components/WritingCredits.jsx -> src/components/WritingEntities.jsx -> src/components/WritingCredits.jsx
> created built/main.js in 438ms

This is required for instances such as those in the below link that include `writingCredits.entities.writingCredits.entities`:

https://github.com/andygout/dramatis-api/blob/68e1d419a923d10d4f49a320bfe7722d5013a14c/test-e2e/model-interaction/mats-with-source-mat.test.js#L399-L514