### PR TITLE
Replace ESLint rule: no-only-tests/no-only-tests -> mocha/no-exclusive-tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,6 @@ const __dirname = path.dirname(__filename);
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import mochaPlugin from 'eslint-plugin-mocha';
-import noOnlyTestsPlugin from 'eslint-plugin-no-only-tests';
 import reactPlugin from 'eslint-plugin-react';
 import globals from 'globals';
 
@@ -98,12 +97,11 @@ export default [
 			}
 		},
 		plugins: {
-			mocha: mochaPlugin,
-			'no-only-tests': noOnlyTestsPlugin
+			mocha: mochaPlugin
 		},
 		rules: {
-			'mocha/no-mocha-arrows': 0,
-			'no-only-tests/no-only-tests': 2
+			'mocha/no-exclusive-tests': 2,
+			'mocha/no-mocha-arrows': 0
 		}
 	}
 ];

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "concurrently": "9.1.0",
     "eslint": "9.17.0",
     "eslint-plugin-mocha": "10.5.0",
-    "eslint-plugin-no-only-tests": "3.3.0",
     "eslint-plugin-react": "7.37.2",
     "globals": "15.14.0",
     "lintspaces-cli": "0.8.0",


### PR DESCRIPTION
[eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) now includes a [`no-exclusive-tests` rule](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md), making the [eslint-plugin-no-only-tests](https://www.npmjs.com/package/eslint-plugin-no-only-tests) `no-only-tests` rule redundant.

This PR switches out `no-only-tests/no-only-tests` in favour of `mocha/no-exclusive-tests` (whose error level has been increased from a warning to an error).

This has the following effect when adding a `.only` to one of the tests then running `$ npm run lint`:

### Before:
```
/{path}/dramatis-ssr/test/src/lib/format-date.test.js
  9:6  warning  Unexpected exclusive mocha test  mocha/no-exclusive-tests
  9:6  error    it.only not permitted            no-only-tests/no-only-tests

✖ 2 problems (1 error, 1 warning)
```

### After:
```
/{path}/dramatis-ssr/test/src/lib/format-date.test.js
  9:6  error  Unexpected exclusive mocha test  mocha/no-exclusive-tests

✖ 1 problem (1 error, 0 warnings)
```

### References:
- [Github: lo1tuma/eslint-plugin-mocha — no-exclusive-tests rule](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md)