### PR TITLE
Apply ESLint browser language options to client directory

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,16 @@ export default [
 	},
 	{
 		files: [
+			'src/client/**/*.js'
+		],
+		languageOptions: {
+			globals: {
+				...globals.browser
+			}
+		}
+	},
+	{
+		files: [
 			'test/**/*.test.js'
 		],
 		languageOptions: {

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -101,7 +101,7 @@ function onConfirm (selectedOption) {
 
 	const instancePath = `/${MODEL_TO_ROUTE_MAP[model]}/${uuid}`;
 
-	location.href = instancePath; // eslint-disable-line no-undef
+	location.href = instancePath;
 
 }
 
@@ -121,9 +121,9 @@ async function customSearchResults (searchTerm, populateOptions) {
 
 }
 
-document.addEventListener('DOMContentLoaded', function () { // eslint-disable-line no-undef
+document.addEventListener('DOMContentLoaded', function () {
 
-	const oAutocompleteElement = document.getElementById('autocomplete'); // eslint-disable-line no-undef
+	const oAutocompleteElement = document.getElementById('autocomplete');
 
 	new oAutocomplete(oAutocompleteElement, { // eslint-disable-line new-cap
 		suggestionTemplate,


### PR DESCRIPTION
This PR applies ESLint browser language options to the `client` directory so that it recognises terms such as `location` and `document`, which currently require `eslint-disable-line no-undef` to prevent those instances from causing errors when `npm run lint` is run.