### PR TITLE
Revise formatDate function

### DIFF
--- a/src/lib/format-date.js
+++ b/src/lib/format-date.js
@@ -10,6 +10,27 @@ export const formatDate = (dateString, customOptions = {}) => {
 
 	const options = Object.assign({}, defaultOptions, customOptions);
 
-	return new Intl.DateTimeFormat('en-GB', options).format(date).replace('Sept', 'Sep');
+	const dateFormatter = new Intl.DateTimeFormat('en-GB', options);
+
+	return dateFormatter
+		.formatToParts(date)
+		.map(part => {
+			// Strip commas from literal parts.
+			if (part.type === 'literal') {
+				return part.value.replace(/,/g, '');
+			}
+
+			// Converts September's short form from 'Sept' to 'Sep'.
+			if (
+				part.type === 'month' &&
+				options.month === 'short' &&
+				part.value === 'Sept'
+			) {
+				return 'Sep';
+			}
+
+			return part.value;
+		})
+		.join('');
 
 };

--- a/test/src/lib/format-date.test.js
+++ b/test/src/lib/format-date.test.js
@@ -6,9 +6,23 @@ describe('Format Date module', () => {
 
 	context('custom options are not provided', () => {
 
-		it('returns a date formatted as to: DD - abbreviated month - YYYY', () => {
+		context('given month is not September', () => {
 
-			expect(formatDate('2021-04-09')).to.equal('09 Apr 2021');
+			it('returns a date formatted as to: DD - abbreviated month - YYYY', () => {
+
+				expect(formatDate('2021-04-09')).to.equal('09 Apr 2021');
+
+			});
+
+		});
+
+		context('given month is September', () => {
+
+			it('returns a date formatted as to: DD - abbreviated month - YYYY; converts \'Sept\' to \'Sep\'', () => {
+
+				expect(formatDate('2021-09-01')).to.equal('01 Sep 2021');
+
+			});
 
 		});
 
@@ -16,9 +30,23 @@ describe('Format Date module', () => {
 
 	context('custom options are provided', () => {
 
-		it('returns a date formatted by factoring in the custom options', () => {
+		context('given month is not September', () => {
 
-			expect(formatDate('2021-04-09', { weekday: 'long', month: 'long' })).to.equal('Friday, 09 April 2021');
+			it('returns a date formatted by factoring in the custom options; strips commas from literal parts', () => {
+
+				expect(formatDate('2021-04-09', { weekday: 'long', month: 'long' })).to.equal('Friday 09 April 2021');
+
+			});
+
+		});
+
+		context('given month is September', () => {
+
+			it('returns a date formatted by factoring in the custom options; strips commas from literal parts', () => {
+
+				expect(formatDate('2021-09-01', { weekday: 'long', month: 'long' })).to.equal('Wednesday 01 September 2021');
+
+			});
 
 		});
 


### PR DESCRIPTION
This PR revises the `formatDate` function so that:
- it achieves consistency of whether a comma is applied to formatted dates (e.g. "Thursday, 31 May 2018"), regardless of whether the code is run on the server-side or client-side
- does not misspell September (when the full name of the month is given on the production page for its dates)

### Before

"Dates" values:
- commas are used
- "September" is misspelled as "Sepember"

<img width="398" height="267" alt="ssr-before" src="https://github.com/user-attachments/assets/30000b51-16ce-4c20-9155-8143bddf13ed" />

---

### After

"Dates" values:
- commas are no longer used
- "September" is no longer misspelled as "Sepember"

<img width="402" height="267" alt="ssr-after" src="https://github.com/user-attachments/assets/d6507cb7-9fd9-47a9-bb96-bb393bdc9ece" />