### PR TITLE
Upgrade express 4.21.2 -> 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@financial-times/o-autocomplete": "1.10.0",
     "@financial-times/o-forms": "9.12.1",
     "@financial-times/o-utils": "2.2.1",
-    "express": "4.21.2",
+    "express": "5.1.0",
     "express-session": "1.18.2",
     "morgan": "1.10.1",
     "preact": "10.27.2",

--- a/src/router.js
+++ b/src/router.js
@@ -77,7 +77,7 @@ router.get('/venues', (request, response, next) =>
 router.get('/venues/:uuid', (request, response, next) =>
 	instancesController(request, response, next));
 
-router.get('*', (request, response, next) => {
+router.use((request, response, next) => {
 
 	const error = new Error('Not Found');
 	error.status = 404;


### PR DESCRIPTION
This PR upgrades [express](https://www.npmjs.com/package/express) from v4.21.2 to v5.1.0.

The below change in `src/router.js` is for a 404 status response: a catch-all middleware with no path.

```diff
- router.get('*', (request, response, next) => response.sendStatus(404));
+ router.use((request, response) => response.sendStatus(404));
```

Without this change will result in an error like this (this stack trace was taken from [dramatis-api](https://github.com/andygout/dramatis-api)):
```
/{path}/node_modules/path-to-regexp/dist/index.js:96 throw new PathError(Missing parameter name at index ${index}, str); ^

PathError [TypeError]: Missing parameter name at index 1: *; visit https://git.new/pathToRegexpError for info
at name (/{path}/node_modules/path-to-regexp/dist/index.js:96:19)
at parse (/{path}/node_modules/path-to-regexp/dist/index.js:113:68)
at pathToRegexp (/{path}/node_modules/path-to-regexp/dist/index.js:267:58)
at Object.match (/{path}/node_modules/path-to-regexp/dist/index.js:237:30)
at matcher (/{path}/node_modules/router/lib/layer.js:86:23)
at new Layer (/{path}/node_modules/router/lib/layer.js:93:62) 
at router.route (/{path}/node_modules/router/index.js:428:17)
at Router.<computed> [as get] (/{path}/node_modules/router/index.js:447:24)
at file:///{path}/src/router.js:112:8
at ModuleJob.run
(node:internal/modules/esm/module_job:371:25) {
	originalPath: '*' 
}
```

### References:
- [Introducing Express v5: A New Era for the Node.js Framework](https://expressjs.com/2024/10/15/v5-release.html)
- [Migrating to Express 5](https://expressjs.com/en/guide/migrating-5)