### PR TITLE
Upgrade o-autocomplete 1.10.0 -> 2.0.0; o-forms 9.12.1 -> 10.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "1.10.0",
-    "@financial-times/o-forms": "9.12.1",
+    "@financial-times/o-autocomplete": "2.0.0",
+    "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "express": "5.1.0",
     "express-session": "1.18.2",

--- a/src/client/stylesheets/_o-autocomplete-modifiers.scss
+++ b/src/client/stylesheets/_o-autocomplete-modifiers.scss
@@ -5,8 +5,12 @@
 }
 
 .o-autocomplete__input {
+	min-height: inherit !important;
 	padding-left: 12px !important;
 	border-radius: 6px !important;
+	font-family: inherit !important;
+	font-size: medium !important;
+	line-height: inherit !important;
 	color: color-variables.$default-text-color;
 }
 
@@ -23,6 +27,10 @@
 
 .o-autocomplete__menu--overlay {
 	top: calc(100% + 2px) !important;
+}
+
+.o-autocomplete__option {
+	font-size: medium;
 }
 
 .o-autocomplete__option--focused,


### PR DESCRIPTION
This PR upgrades the following packages to their current latest version:
- @financial-times/o-autocomplete
- @financial-times/o-forms

It also applies CSS changes to ensure the component looks as it did prior to the upgrades.