### PR TITLE
Upgrade sass 1.77.4 -> 1.93.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-scss": "4.0.1",
     "rollup-plugin-watch-globs": "2.0.1",
-    "sass": "1.77.4"
+    "sass": "1.93.2"
   }
 }


### PR DESCRIPTION
This upgrades sass to the current latest version.

This results in the below warnings when running `npm run build` or when a build is triggered when the server is running owing to code changes.

This will be addressed in a subsequent PR (https://github.com/andygout/dramatis-ssr/pull/281).

```
src/client/stylesheets/index.scss → public...
Deprecation Warning [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
17 │ @import '@financial-times/o-autocomplete/main';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 17:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
18 │ @import '@financial-times/o-forms/main';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 18:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import '@financial-times/math';
  │         ^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@financial-times/o-autocomplete/main.scss 1:9  @import
    stdin 17:9                                                  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │ @import '@financial-times/o-brand/main';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@financial-times/o-autocomplete/main.scss 2:9  @import
    stdin 17:9                                                  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
3 │ @import '@financial-times/o-loading/main';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@financial-times/o-autocomplete/main.scss 3:9  @import
    stdin 17:9                                                  root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use map.get instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
14 │     @return map-get($_by-brand, $brand);
   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@financial-times/o-private-foundation/src/scss/_tokens.scss 14:10  forBrand()
    node_modules/@financial-times/o-private-foundation/src/scss/_brand.scss 5:31    @import
    node_modules/@financial-times/o-private-foundation/main.scss 1:9                @import
    node_modules/@financial-times/o-loading/main.scss 2:9                           @import
    node_modules/@financial-times/o-autocomplete/main.scss 3:9                      @import
    stdin 17:9                                                                      root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use list.index instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
131 │     @if not index($_o-brand-available-brands, $current-brand) {
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-brand/scss/_public-functions.scss 131:10      oBrandIs()
    node_modules/@financial-times/o-private-foundation/src/scss/_brand.scss 28:5  @import
    node_modules/@financial-times/o-private-foundation/main.scss 1:9              @import
    node_modules/@financial-times/o-loading/main.scss 2:9                         @import
    node_modules/@financial-times/o-autocomplete/main.scss 3:9                    @import
    stdin 17:9                                                                    root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use map.merge instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
34 │ ┌                 map-merge(
35 │ │                     $o-private-foundation-tokens,
36 │ │                     (
37 │ │                         // FT professional is treated as a theme in Origami v2.
38 │ │                         'professional': tokens.forBrand('professional')
39 │ │                     )
40 │ │                 ),
   │ └─────────────────^
   ╵
    node_modules/@financial-times/o-private-foundation/src/scss/_brand.scss 34:5  @import
    node_modules/@financial-times/o-private-foundation/main.scss 1:9              @import
    node_modules/@financial-times/o-loading/main.scss 2:9                         @import
    node_modules/@financial-times/o-autocomplete/main.scss 3:9                    @import
    stdin 17:9                                                                    root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use meta.type-of instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
134 │     @if type-of($name) != 'string' {
    │         ^^^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-brand/scss/_private-functions.scss 134:6      -oBrandValidateName()
    node_modules/@financial-times/o-brand/scss/_mixins.scss 13:25                 oBrandDefine()
    node_modules/@financial-times/o-private-foundation/src/scss/_brand.scss 29:2  @import
    node_modules/@financial-times/o-private-foundation/main.scss 1:9              @import
    node_modules/@financial-times/o-loading/main.scss 2:9                         @import
    node_modules/@financial-times/o-autocomplete/main.scss 3:9                    @import
    stdin 17:9                                                                    root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use string.length instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
145 │     @for $character-index from 1 through str-length($name) {
    │                                          ^^^^^^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-brand/scss/_private-functions.scss 145:39     -oBrandValidateName()
    node_modules/@financial-times/o-brand/scss/_mixins.scss 13:25                 oBrandDefine()
    node_modules/@financial-times/o-private-foundation/src/scss/_brand.scss 29:2  @import
    node_modules/@financial-times/o-private-foundation/main.scss 1:9              @import
    node_modules/@financial-times/o-loading/main.scss 2:9                         @import
    node_modules/@financial-times/o-autocomplete/main.scss 3:9                    @import
    stdin 17:9                                                                    root stylesheet

Deprecation Warning [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
191 │     $red-component: red($color);
    │                     ^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 191:18  oPrivateColorsColorBrightness()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 146:20  oPrivateColorsGetTextColor()
    node_modules/@financial-times/o-autocomplete/main.scss 148:10                                oAutocomplete()
    stdin 19:1                                                                                   root stylesheet

Deprecation Warning [color-functions]: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
192 │     $green-component: green($color);
    │                       ^^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 192:20  oPrivateColorsColorBrightness()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 146:20  oPrivateColorsGetTextColor()
    node_modules/@financial-times/o-autocomplete/main.scss 148:10                                oAutocomplete()
    stdin 19:1                                                                                   root stylesheet

Deprecation Warning [color-functions]: blue() is deprecated. Suggestion:

color.channel($color, "blue", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
193 │     $blue-component: blue($color);
    │                      ^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 193:19  oPrivateColorsColorBrightness()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 146:20  oPrivateColorsGetTextColor()
    node_modules/@financial-times/o-autocomplete/main.scss 148:10                                oAutocomplete()
    stdin 19:1                                                                                   root stylesheet

Deprecation Warning [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
211 │         'red': red($color),
    │                ^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 211:10  oPrivateColorsColorLuminance()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 239:7   oPrivateColorsGetContrastRatio()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 148:21  oPrivateColorsGetTextColor()
    node_modules/@financial-times/o-autocomplete/main.scss 148:10                                oAutocomplete()
    stdin 19:1                                                                                   root stylesheet

Deprecation Warning [color-functions]: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
212 │         'green': green($color),
    │                  ^^^^^^^^^^^^^
    ╵
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 212:12  oPrivateColorsColorLuminance()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 239:7   oPrivateColorsGetContrastRatio()
    node_modules/@financial-times/o-private-foundation/src/scss/o-colors/_functions.scss 148:21  oPrivateColorsGetTextColor()
    node_modules/@financial-times/o-autocomplete/main.scss 148:10                                oAutocomplete()
    stdin 19:1                                                                                   root stylesheet

Warning: 238 repetitive deprecation warnings omitted.
```