### PR TITLE
Use Sass modern compiler API

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup": "4.52.0",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-esbuild": "6.2.1",
-    "rollup-plugin-scss": "4.0.1",
+    "rollup-plugin-sass": "1.15.3",
     "rollup-plugin-watch-globs": "2.0.1",
     "sass": "1.93.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,10 @@
+import path from 'node:path';
+
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import copy from 'rollup-plugin-copy';
 import esbuild from 'rollup-plugin-esbuild';
-import scss from 'rollup-plugin-scss';
+import sassPlugin from 'rollup-plugin-sass';
 import watchGlobs from 'rollup-plugin-watch-globs';
 import * as sass from 'sass';
 
@@ -70,10 +72,22 @@ const clientStylesBundle = {
 		watchGlobs([
 			'src/client/stylesheets/**/*.scss'
 		]),
-		scss({
-			fileName: 'main.css',
-			failOnError: true,
-			sass
+		sassPlugin({
+			output: 'public/main.css',
+			api: 'modern',
+			runtime: sass,
+			options: {
+				// Let @import find packages' stylesheets by looking in node_modules directory.
+				loadPaths: [
+					path.resolve('node_modules')
+				],
+				// Until dependencies have migrated to Sass's modern compiler API.
+				silenceDeprecations: [
+					'import',
+					'global-builtin',
+					'color-functions'
+				]
+			}
 		})
 	]
 };


### PR DESCRIPTION
This PR address the warnings that were appearing in asset builds as described in the description of PR https://github.com/andygout/dramatis-ssr/pull/280.

It does this by switching [rollup-plugin-scss](https://www.npmjs.com/package/rollup-plugin-scss) for [rollup-plugin-sass](https://www.npmjs.com/package/rollup-plugin-sass) (configured to use Sass's modern compiler API).

- rollup-plugin-scss: calls Sass's legacy JavaScript API (`sass.renderSync`)
- rollup-plugin-sass: can be configured to call Sass's modern compiler API (`sass.compile*()`)

`silenceDeprecations` is configured to suppress the warnings in asset builds caused by packages' (i.e. @financial-times/o-autocomplete and @financial-times/o-forms) stylesheets using the legacy JavaScript API. Once those packages have migrated to Sass's modern compiler API then this suppression can be removed.

The code in this repo has already switched out `@import` for `@use` (in PR https://github.com/andygout/dramatis-ssr/pull/193), so it is only the packages that require the accommodations provided by this PR.

### References:
- [Sass: Breaking Change: @import and global built-in functions](https://sass-lang.com/documentation/breaking-changes/import)
- [GitHub: twbs/bootstrap — Issues: dart-sass 1.80.0+ throwing a lot of deprecations](https://github.com/twbs/bootstrap/issues/40962)

### New dev dependencies:
- [rollup-plugin-sass](https://www.npmjs.com/package/rollup-plugin-sass)