### PR TITLE
Fix .editorconfig file patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,13 +5,13 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
-[**{.js,.jsx,.scss}]
+[*.{js,jsx,scss}]
 indent_style = tab
 indent_size = tab
 tab_width = 4
 trim_trailing_whitespace = true
 
-[**{.json}]
+[*.json]
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true


### PR DESCRIPTION
This PR fixes the .editorconfig file so that the file pattern for files with a `.json` extension are correctly identified.

It also makes the file pattern for files with a `.js`, `.jsx`, or `.scss` extension more succinct (though both the "before" and "after" file patterns have the same effect).

### References:
- [EditorConfig](https://editorconfig.org)