### PR TITLE
Upgrade o-autocomplete 2.0.0 -> 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "2.0.0",
+    "@financial-times/o-autocomplete": "2.1.0",
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "express": "5.1.0",

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -27,37 +27,9 @@ async function getSearchResults (searchTerm) {
 
 }
 
-function highlightSuggestion (suggestion, query) {
+function suggestionTemplate (option, query, highlightSuggestion, isHighlightCorrespondingToMatch) {
 
-	const result = suggestion.split('');
-
-	const matchIndex = suggestion.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
-
-	return result.map((character, index) => {
-
-		let shouldHighlight = false;
-
-		const hasMatched = matchIndex > -1;
-
-		const characterIsWithinMatch =
-			index >= matchIndex &&
-			index <= matchIndex + query.length - 1;
-
-		if (hasMatched && characterIsWithinMatch) {
-
-			shouldHighlight = true;
-
-		}
-
-		return [character, shouldHighlight];
-
-	});
-
-}
-
-function suggestionTemplate (option, query) {
-
-	const characters = highlightSuggestion(option.name, query || option.name);
+	const characters = highlightSuggestion(option.name, query || option.name, isHighlightCorrespondingToMatch);
 
 	let highlightedOptionName = '';
 
@@ -127,6 +99,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	new oAutocomplete(oAutocompleteElement, { // eslint-disable-line new-cap
 		suggestionTemplate,
+		isHighlightCorrespondingToMatch: true,
 		mapOptionToSuggestedValue,
 		onConfirm,
 		source: debounce(customSearchResults, 1000)


### PR DESCRIPTION
This PR upgrades the @financial-times/o-autocomplete Origami package from v2.0.0 to [v2.1.0](https://github.com/Financial-Times/origami/releases/tag/o-autocomplete-v2.1.0).

This latest minor version adds configurable highlighting: specifying `isHighlightCorrespondingToMatch: true` means that the part of the result that matches the search term will be highlighted (i.e. bold) rather than the other way around as is the default.

This in turn removes the need to declare a native `highlightSuggestion` function in this repo, which previously did the work of deciding what characters in the result should be highlighted, and which was mostly a duplicate of the native o-autocomplete `highlightSuggestion`  function (they were identical except for the two instances of assigning a Boolean value to `shouldHighlight`, which were reversed).

### References:
- [GitHub: Financial-Times/origami — Pull requests — feat: Add o-autocomplete configurable highlighting](https://github.com/Financial-Times/origami/pull/1658)
- [GitHub: Financial-Times/origami — Releases / o-autocomplete-v2.1.0](https://github.com/Financial-Times/origami/releases/tag/o-autocomplete-v2.1.0)