### PR TITLE
Revise lib export types

### DIFF
--- a/src/components/AppendedDate.jsx
+++ b/src/components/AppendedDate.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { formatDate } from '../lib/format-date.js';
+import formatDate from '../lib/format-date.js';
 
 const AppendedDate = props => {
 

--- a/src/components/AppendedProductionDates.jsx
+++ b/src/components/AppendedProductionDates.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'preact';
 
-import { formatDate } from '../lib/format-date.js';
+import formatDate from '../lib/format-date.js';
 
 const AppendedProductionDates = props => {
 

--- a/src/lib/fetch-from-api.js
+++ b/src/lib/fetch-from-api.js
@@ -1,6 +1,6 @@
 const API_URL_BASE = 'http://localhost:3000';
 
-export default async apiPath => {
+const fetchFromApi = async apiPath => {
 
 	const apiUrl = `${API_URL_BASE}${apiPath}`;
 
@@ -41,3 +41,5 @@ export default async apiPath => {
 	}
 
 };
+
+export default fetchFromApi;

--- a/src/lib/format-date.js
+++ b/src/lib/format-date.js
@@ -1,4 +1,4 @@
-export const formatDate = (dateString, customOptions = {}) => {
+const formatDate = (dateString, customOptions = {}) => {
 
 	const date = new Date(dateString);
 
@@ -34,3 +34,5 @@ export const formatDate = (dateString, customOptions = {}) => {
 		.join('');
 
 };
+
+export default formatDate;

--- a/src/lib/get-differentiator-suffix.js
+++ b/src/lib/get-differentiator-suffix.js
@@ -1,4 +1,4 @@
-export default differentiator => {
+const getDifferentiatorSuffix = differentiator => {
 
 	if (!differentiator) return '';
 
@@ -7,3 +7,5 @@ export default differentiator => {
 	return ` (${differentiatorDisplayValue})`;
 
 };
+
+export default getDifferentiatorSuffix;

--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -1,6 +1,6 @@
 import { MODELS } from '../utils/constants.js';
 
-export default instance => {
+const getInstanceTitle = instance => {
 
 	const { name } = instance;
 
@@ -26,3 +26,5 @@ export default instance => {
 	}
 
 };
+
+export default getInstanceTitle;

--- a/src/pages/instances/Production.jsx
+++ b/src/pages/instances/Production.jsx
@@ -16,7 +16,7 @@ import {
 	ProductionTeamCreditsList,
 	VenueLinkWithContext
 } from '../../components/index.js';
-import { formatDate } from '../../lib/format-date.js';
+import formatDate from '../../lib/format-date.js';
 
 const Production = props => {
 

--- a/test/src/lib/format-date.test.js
+++ b/test/src/lib/format-date.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { formatDate } from '../../../src/lib/format-date.js';
+import formatDate from '../../../src/lib/format-date.js';
 
 describe('Format Date module', () => {
 


### PR DESCRIPTION
This PR applies to consistency to the following export type conventions in the `lib` directory:
- If a module exports multiple (or the intention/potential to export multiple) functions, then they are declared at the end of the file with `export { … };`
- If a module exports a single function which will only ever be the sole function exported by the module (indicated by the function name being the same as the filename), then it is declared at the outset (e.g. `const functionName = () => {`) and then exported at the bottom with `export default functionName;`
  - The reason `export default () => {` is not used is because it is quite useful to have the function named in the module itself so that when searching for instances of the function, the results include not only its invocations but also its declaration