### PR TITLE
Restore search bar clear button icon

### DIFF
--- a/src/client/stylesheets/origami.scss
+++ b/src/client/stylesheets/origami.scss
@@ -1,4 +1,4 @@
-$system-code: '$$$-no-bizops-system-code-$$$'; // Required for Origami components.
+$system-code: 'image-service'; // Required for Origami components.
 
 @import '@financial-times/o-autocomplete/main';
 @import '@financial-times/o-forms/main';


### PR DESCRIPTION
The accepted `source` query param value for hobby projects using Origami o-icons has changed from `$$$-no-bizops-system-code-$$$` to `image-service`.

Making a request for an o-icon using `?source=$$$-no-bizops-system-code-$$$` (e.g. https://images.ft.com/v3/image/raw/fticon-v1:cross?source=$$$-no-bizops-system-code-$$$&tint=%2333302E,%2333302E&format=svg) now returns:

```json
{
	"error": "A valid source is required"	
}
```

Using `?source=image-service` (e.g. https://images.ft.com/v3/image/raw/fticon-v1:cross?source=image-service&tint=%2333302E,%2333302E&format=svg) will successfully return the icon.

The [Build Service documentation](https://www.ft.com/__origami/service/build/v3/docs/api#get-v3-bundles-js) that still recommends the old and now redundant query param value will be updated in due course.