### PR TITLE
Adjust search bar input padding-right

### DIFF
--- a/src/client/stylesheets/modifiers/o-autocomplete-modifiers.css
+++ b/src/client/stylesheets/modifiers/o-autocomplete-modifiers.css
@@ -2,8 +2,11 @@
 	width: 100%;
 
 	.o-autocomplete__input {
+		--clear-input-button-width: 25px;
+
 		min-height: inherit;
 		padding-left: 12px;
+		padding-right: var(--clear-input-button-width);
 		border-radius: 6px;
 		font-family: inherit;
 		font-size: medium;


### PR DESCRIPTION
This PR reduces the padding-right value so that the input text can go closer to the clear input button.

### Before

#### UI
<img width="997" height="327" alt="before" src="https://github.com/user-attachments/assets/f5fde635-f7fb-4f86-bbc2-0a4f32d43d71" />

#### DOM
<img width="508" height="271" alt="dom-before" src="https://github.com/user-attachments/assets/d9b9f580-fc7f-4b4a-834d-a89277cdeffd" />

### After

#### UI
<img width="998" height="328" alt="after" src="https://github.com/user-attachments/assets/c3dd8fe2-83c7-4a40-a6b7-2463027f262f" />

#### DOM
<img width="508" height="271" alt="dom-after" src="https://github.com/user-attachments/assets/0d233d1c-ff59-4d47-b069-569065c50041" />