### PR TITLE
Encode searchTerm query param value

### DIFF
--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -19,7 +19,7 @@ async function performFetch (url) {
 
 async function getSearchResults (searchTerm) {
 
-	const url = `${URL_BASE}/api/search?searchTerm=${searchTerm}`;
+	const url = `${URL_BASE}/api/search?searchTerm=${encodeURIComponent(searchTerm)}`;
 
 	const searchResults = await performFetch(url);
 

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -6,7 +6,7 @@ export default async (request, response, next) => {
 
 	try {
 
-		const searchResults = await fetchFromApi(`/search?searchTerm=${searchTerm}`);
+		const searchResults = await fetchFromApi(`/search?searchTerm=${encodeURIComponent(searchTerm)}`);
 
 		return response.send(searchResults);
 


### PR DESCRIPTION
This PR ensures that the `searchTerm` query param value is encoded at the following points:
- client-side request to this app's `/search` API endpoint
- server-side request to the dramatis-api `/search` API endpoint

This will prevent unexpected behaviour when the `searchTerm` value includes characters that are part of the URI syntax, e.g. `&`, `?`, etc.

Given the following input search term: `romeo & juliet`, the resultant value acquired from `request.query.searchTerm` upon receipt of request is:

**Before:** `romeo`

**After:** `romeo & juliet`

### References:
- [MDN — JavaScript: encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)