### PR TITLE
Confine home page link to header text

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,11 @@ const Header = () => {
 	return (
 		<header className="header">
 
-			<a href='/' className="header__component header__home-link">Dramatis</a>
+			<div className="header__component">
+
+				<a href='/' className="header__home-link">Dramatis</a>
+
+			</div>
 
 			<span className="header__component o-forms-input o-forms-input--text">
 				<span id="autocomplete" className="o-autocomplete">


### PR DESCRIPTION
This PR modifies the home page link in the header to just the header text rather than the entire width of the header up until the point where the search bar starts.

Currently, the user can hover the mouse in the black area between the text and search bar and the text will apply its hover styling (and link to the home page when clicked), which feels unexpected.

This revised UI feels a lot more conventional and intuitive.

### Before
<img width="1005" height="137" alt="before" src="https://github.com/user-attachments/assets/483d5ca0-c481-46ef-9d4c-021694bc5334" />

### After
<img width="1004" height="117" alt="after" src="https://github.com/user-attachments/assets/c32135d6-2581-4301-b757-a6e5fbe3f94d" />