### PR TITLE
Trim searchTerm query param value

### DIFF
--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -19,7 +19,7 @@ async function performFetch (url) {
 
 async function getSearchResults (searchTerm) {
 
-	const url = `${URL_BASE}/api/search?searchTerm=${encodeURIComponent(searchTerm)}`;
+	const url = `${URL_BASE}/api/search?searchTerm=${encodeURIComponent(searchTerm.trim())}`;
 
 	const searchResults = await performFetch(url);
 

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -4,9 +4,11 @@ export default async (request, response, next) => {
 
 	const { query: { searchTerm } } = request;
 
+	if (!searchTerm) return response.send([]);
+
 	try {
 
-		const searchResults = await fetchFromApi(`/search?searchTerm=${encodeURIComponent(searchTerm)}`);
+		const searchResults = await fetchFromApi(`/search?searchTerm=${encodeURIComponent(searchTerm.trim())}`);
 
 		return response.send(searchResults);
 


### PR DESCRIPTION
This PR ensures that `searchTerm` query params submitted as values in queries to search APIs are trimmed.

All values stored in the database will have been trimmed so any search values should similarly be trimmed before trying to find a match.