### PR TITLE
Revise search bar options styling

### DIFF
--- a/src/client/stylesheets/lib/color-variables.css
+++ b/src/client/stylesheets/lib/color-variables.css
@@ -1,5 +1,10 @@
 :root {
 	--autocomplete-option-suffix-color: #949494;
+	--autocomplete-option-background-color-hover: color-mix(
+		in srgb,
+		var(--autocomplete-selected-option-background-color),
+		transparent 90%
+	);
 	--autocomplete-selected-option-background-color: #006699;
 	--autocomplete-selected-option-color: #FFFFFF;
 	--border-color: #949494;

--- a/src/client/stylesheets/modifiers/o-autocomplete-modifiers.css
+++ b/src/client/stylesheets/modifiers/o-autocomplete-modifiers.css
@@ -33,10 +33,17 @@
 		font-size: medium;
 	}
 
-	.o-autocomplete__option--focused,
 	.o-autocomplete__option:hover {
+		background-color: var(--autocomplete-option-background-color-hover);
+		border-color: var(--autocomplete-option-background-color-hover);
+		color: var(--default-text-color);
+	}
+
+	.o-autocomplete__option--focused,
+	.o-autocomplete__option--focused:hover {
 		background-color: var(--autocomplete-selected-option-background-color);
 		border-color: var(--autocomplete-selected-option-background-color);
+		color: var(--autocomplete-selected-option-color);
 
 		.o-autocomplete__option-suffix {
 			color: var(--autocomplete-selected-option-color);


### PR DESCRIPTION
This PR revises the search bar options styling to bring the hover state more in line with the thematic styling of the site (its background colour becomes a more transparent instance of the blue used for various aspects).

### Hover

- Mouse is hovered over Ian McNeil

| Before | After |
| ------ | ------ |
|<img width="511" height="275" alt="before-hover" src="https://github.com/user-attachments/assets/18f728a4-a391-4e3a-b23b-a3b7fddf1772" />|<img width="509" height="277" alt="after-hover" src="https://github.com/user-attachments/assets/87c12da3-5737-4e9f-84c3-247ec773057c" />|

### Selected (no change)

- Ian McNeil has been selected by using directional keys whilst focused on search bar input

| Before | After |
| ------ | ------ |
|<img width="509" height="276" alt="before-selected" src="https://github.com/user-attachments/assets/190a9742-14fc-482b-8380-7fddaa16fd34" />|<img width="510" height="275" alt="after-selected" src="https://github.com/user-attachments/assets/54203bc1-1a23-475c-ba27-4d22fb9b25d6" />|

### Hover on then selected same option (no change)

- The mouse is hovered over Ian McNeil and that option has then been selected by using directional keys whilst focused on search bar input

| Before | After |
| ------ | ------ |
|<img width="509" height="276" alt="before-hover-then-selected" src="https://github.com/user-attachments/assets/d72131f2-c28a-4ca8-bbc5-3b46d167d33e" />|<img width="510" height="275" alt="after-hover-then-selected" src="https://github.com/user-attachments/assets/75a55465-e658-4bb8-b61c-6d4521089f07" />|

### Selected then hover on same option

- Ian McNeil has been selected by using directional keys whilst focused on search bar input and the mouse is has then been hovered over him

| Before | After |
| ------ | ------ |
|<img width="509" height="276" alt="before-selected-then-hover" src="https://github.com/user-attachments/assets/7147b847-8c4b-4ead-8560-1cab01643b0d" />|<img width="509" height="277" alt="after-selected-then-hover" src="https://github.com/user-attachments/assets/ac3b4376-3d84-43a1-a14c-67a4b274c226" />|

### Selected and hover on different options

- Ian McNeil has been selected by using directional keys whilst focused on search bar input
- Mouse is hovered over Ian Farmery

| Before | After |
| ------ | ------ |
|<img width="513" height="278" alt="before-selected-and-hover" src="https://github.com/user-attachments/assets/626f4c5e-4205-4cb7-8c81-c4bbd489eba4" />|<img width="508" height="273" alt="after-selected-and-hover" src="https://github.com/user-attachments/assets/5e3cb8a6-9637-4fe7-9d16-c635aabffff0" />|
