### PR TITLE
Upgrade o-autocomplete 2.1.0 -> 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "2.1.0",
+    "@financial-times/o-autocomplete": "2.2.0",
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "express": "5.1.0",

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -101,7 +101,9 @@ document.addEventListener('DOMContentLoaded', function () {
 		suggestionTemplate,
 		isHighlightCorrespondingToMatch: true,
 		mapOptionToSuggestedValue,
+		confirmOnBlur: false,
 		onConfirm,
+		showNoOptionsFound: true,
 		source: debounce(customSearchResults, 1000)
 	});
 

--- a/src/client/stylesheets/overrides/o-autocomplete-overrides.css
+++ b/src/client/stylesheets/overrides/o-autocomplete-overrides.css
@@ -53,4 +53,9 @@
 	.o-autocomplete__option-suffix {
 		color: var(--autocomplete-option-suffix-color);
 	}
+
+	.o-autocomplete__option--no-results {
+		background-color: inherit;
+		color: inherit;
+	}
 }


### PR DESCRIPTION
This PR upgrades o-autocomplete from v2.1.0 to v2.2.0, which includes the following changes (see those PR descriptions for details) and changes to utilise the new features:
- [Financial-Times/origami: fix: Add o-autocomplete clear button post-click logic](https://github.com/Financial-Times/origami/pull/2320)
- [Financial-Times/origami: feat: Add o-autocomplete showNoOptionsFound option](https://github.com/Financial-Times/origami/pull/2321)
- [Financial-Times/origami: feat: Add o-autocomplete confirmOnBlur option](https://github.com/Financial-Times/origami/pull/2322)