### PR TITLE
Change source of @financial-times/o-autocomplete dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "2.2.0",
+    "@financial-times/o-autocomplete": "github:andygout/autocomplete#v1.0.0",
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "express": "5.1.0",


### PR DESCRIPTION
This PR changes the source of the @financial-times/o-autocomplete so that it now depends on the following packages:
- https://github.com/andygout/autocomplete; which in turn depends on
- https://github.com/andygout/accessible-autocomplete

This approach allows me greater control and faster release of the changes I require for my project.