### PR TITLE
Upgrade autocomplete 1.0.0 -> 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "github:andygout/autocomplete#v1.0.0",
+    "@financial-times/o-autocomplete": "github:andygout/autocomplete#v1.1.0",
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "express": "5.1.0",

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -101,6 +101,7 @@ document.addEventListener('DOMContentLoaded', function () {
 		suggestionTemplate,
 		isHighlightCorrespondingToMatch: true,
 		mapOptionToSuggestedValue,
+		reopenOnFocusWhenValid: true,
 		confirmOnBlur: false,
 		onConfirm,
 		showNoOptionsFound: true,


### PR DESCRIPTION
This PR upgrades the autocomplete dependency (currently named @financial-times/o-autocomplete, but will shortly be renamed to reflect the new source) so that it can use the `reopenOnFocusWhenValid` prop as detailed in these related PRs:
- https://github.com/andygout/autocomplete/pull/1
- https://github.com/andygout/accessible-autocomplete/pull/2