### PR TITLE
Rename @financial-times/o-autocomplete -> autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-autocomplete": "github:andygout/autocomplete#v1.1.0",
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
+    "autocomplete": "github:andygout/autocomplete#v1.1.1",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "morgan": "1.10.1",

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -1,4 +1,4 @@
-import oAutocomplete from '@financial-times/o-autocomplete';
+import Autocomplete from 'autocomplete';
 import { debounce } from '@financial-times/o-utils';
 
 import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants.js';
@@ -95,9 +95,9 @@ async function customSearchResults (searchTerm, populateOptions) {
 
 document.addEventListener('DOMContentLoaded', function () {
 
-	const oAutocompleteElement = document.getElementById('autocomplete');
+	const autocompleteElement = document.getElementById('autocomplete');
 
-	new oAutocomplete(oAutocompleteElement, { // eslint-disable-line new-cap
+	new Autocomplete(autocompleteElement, {
 		suggestionTemplate,
 		isHighlightCorrespondingToMatch: true,
 		mapOptionToSuggestedValue,

--- a/src/client/stylesheets/scss-imports/origami.scss
+++ b/src/client/stylesheets/scss-imports/origami.scss
@@ -1,7 +1,7 @@
 $system-code: 'image-service'; // Required for Origami components.
 
-@import '@financial-times/o-autocomplete/main';
 @import '@financial-times/o-forms/main';
+@import 'autocomplete/main';
 
 @include oAutocomplete();
 @include oForms();


### PR DESCRIPTION
This PR renames the `@financial-times/o-autocomplete` dependency to `autocomplete` to reflect that the package is now coming from a different source.

It also upgrades the said package to a version (whose changes are in this PR https://github.com/andygout/autocomplete/pull/2) that in turn renames its `@financial-times/accessible-autocomplete` dependency to `accessible-autocomplete` (again to reflect that it is coming from a different source).