### PR TITLE
Upgrade autocomplete 1.1.1 -> 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
-    "autocomplete": "github:andygout/autocomplete#v1.1.1",
+    "autocomplete": "github:andygout/autocomplete#v1.1.2",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "morgan": "1.10.1",


### PR DESCRIPTION
This PR upgrades autocomplete to the current latest version: [1.1.2](https://github.com/andygout/autocomplete/releases/tag/v1.1.2), which includes the changes of this PR: https://github.com/andygout/autocomplete/pull/3.