### PR TITLE
Remove @financial-times/o-forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-forms": "10.0.4",
     "@financial-times/o-utils": "2.2.1",
     "autocomplete": "github:andygout/autocomplete#v1.1.2",
     "express": "5.1.0",

--- a/src/client/stylesheets/autocomplete.css
+++ b/src/client/stylesheets/autocomplete.css
@@ -1,0 +1,5 @@
+.autocomplete__wrapper input {
+	border: 1px;
+	padding: 0.5rem 1rem;
+	width: 100%;
+}

--- a/src/client/stylesheets/overrides/o-forms-overrides.css
+++ b/src/client/stylesheets/overrides/o-forms-overrides.css
@@ -1,3 +1,0 @@
-.o-forms-input {
-	margin-top: 0;
-}

--- a/src/client/stylesheets/scss-imports/origami.scss
+++ b/src/client/stylesheets/scss-imports/origami.scss
@@ -1,7 +1,5 @@
 $system-code: 'image-service'; // Required for Origami components.
 
-@import '@financial-times/o-forms/main';
 @import 'autocomplete/main';
 
 @include oAutocomplete();
-@include oForms();

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -11,6 +11,7 @@ const Head = props => {
 
 			<link rel="stylesheet" href="/stylesheets/color-variables.css" />
 
+			<link rel="stylesheet" href="/stylesheets/autocomplete.css" />
 			<link rel="stylesheet" href="/stylesheets/footer.css" />
 			<link rel="stylesheet" href="/stylesheets/header.css" />
 			<link rel="stylesheet" href="/stylesheets/instance.css" />
@@ -22,7 +23,6 @@ const Head = props => {
 			<link rel="stylesheet" href="/stylesheets/scss-imports.css" />
 
 			<link rel="stylesheet" href="/stylesheets/o-autocomplete-overrides.css" />
-			<link rel="stylesheet" href="/stylesheets/o-forms-overrides.css" />
 
 			<script src="/scripts/main.js" />
 		</head>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,7 +9,7 @@ const Header = () => {
 
 			</div>
 
-			<span className="header__component o-forms-input o-forms-input--text">
+			<span className="header__component autocomplete__wrapper">
 				<span id="autocomplete" className="o-autocomplete">
 					<input id="autocomplete-input" type="text" placeholder="Search Dramatis…" />
 				</span>


### PR DESCRIPTION
The only requirement there was for the @financial-times/o-forms dependency was for the small amount of styling that will now be provided by the styles in src/client/stylesheets/autocomplete.css.