### PR TITLE
Replace autocomplete SCSS with CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@financial-times/o-utils": "2.2.1",
-    "autocomplete": "github:andygout/autocomplete#v1.1.2",
+    "autocomplete": "github:andygout/autocomplete#v2.0.0",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "morgan": "1.10.1",
@@ -50,12 +50,11 @@
     "globals": "16.4.0",
     "lintspaces-cli": "1.0.0",
     "mocha": "11.7.2",
+    "postcss-import": "^16.1.1",
     "pre-commit": "1.2.2",
     "rollup": "4.52.0",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-esbuild": "6.2.1",
-    "rollup-plugin-sass": "1.15.3",
-    "rollup-plugin-watch-globs": "2.0.1",
-    "sass": "1.93.2"
+    "rollup-plugin-postcss": "^4.0.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,9 @@
-import path from 'node:path';
-
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import postcssImport from 'postcss-import';
 import copy from 'rollup-plugin-copy';
 import esbuild from 'rollup-plugin-esbuild';
-import sassPlugin from 'rollup-plugin-sass';
-import watchGlobs from 'rollup-plugin-watch-globs';
-import * as sass from 'sass';
+import postcss from 'rollup-plugin-postcss';
 
 const serverBundle = {
 	input: 'src/app.js',
@@ -61,8 +58,6 @@ const clientScriptsBundle = {
 };
 
 const clientStylesBundle = {
-	// Rollup requires a JavaScript entry point.
-	// index.js is a placeholder for this purpose.
 	input: 'src/client/stylesheets/index.js',
 	output: {
 		dir: 'public'
@@ -71,49 +66,15 @@ const clientStylesBundle = {
 		clearScreen: false
 	},
 	plugins: [
-		watchGlobs([
-			'src/client/stylesheets/**/*.css'
-		]),
-		copy({
-			targets: [
-				{
-					src: 'src/client/stylesheets/**/*.css',
-					dest: 'public/stylesheets',
-					flatten: false
-				}
-			]
-		})
-	]
-};
-
-const clientScssImportsStylesBundle = {
-	input: 'src/client/stylesheets/scss-imports/index.scss',
-	output: {
-		dir: 'public'
-	},
-	watch: {
-		clearScreen: false
-	},
-	plugins: [
-		watchGlobs([
-			'src/client/stylesheets/scss-imports/**/*.scss'
-		]),
-		sassPlugin({
-			output: 'public/stylesheets/scss-imports.css',
-			api: 'modern',
-			runtime: sass,
-			options: {
-				// Let @import find packages' stylesheets by looking in node_modules directory.
-				loadPaths: [
-					path.resolve('node_modules')
-				],
-				// Until dependencies have migrated to Sass's modern compiler API.
-				silenceDeprecations: [
-					'import',
-					'global-builtin',
-					'color-functions'
-				]
-			}
+		nodeResolve({
+			browser: true
+		}),
+		postcss({
+			plugins: [
+				postcssImport()
+			],
+			extract: 'stylesheets/main.css',
+			minimize: false
 		})
 	]
 };
@@ -121,6 +82,5 @@ const clientScssImportsStylesBundle = {
 export default [
 	serverBundle,
 	clientScriptsBundle,
-	clientStylesBundle,
-	clientScssImportsStylesBundle
+	clientStylesBundle
 ];

--- a/src/client/stylesheets/index.js
+++ b/src/client/stylesheets/index.js
@@ -1,2 +1,1 @@
-// Entry point for Rollup.js to trigger copying CSS files into public directory.
-// This file is intentionally empty.
+import './main.css';

--- a/src/client/stylesheets/main.css
+++ b/src/client/stylesheets/main.css
@@ -1,0 +1,16 @@
+/* Ordering of stylesheet groups is important. */
+@import './normalize.css';
+
+@import './lib/color-variables.css';
+
+@import './autocomplete.css';
+@import './footer.css';
+@import './header.css';
+@import './instance.css';
+@import './list.css';
+@import './navigation.css';
+@import './page.css';
+@import './text.css';
+
+@import 'autocomplete/main.css';
+@import './overrides/o-autocomplete-overrides.css';

--- a/src/client/stylesheets/scss-imports/index.scss
+++ b/src/client/stylesheets/scss-imports/index.scss
@@ -1,1 +1,0 @@
-@import 'origami';

--- a/src/client/stylesheets/scss-imports/origami.scss
+++ b/src/client/stylesheets/scss-imports/origami.scss
@@ -1,5 +1,0 @@
-$system-code: 'image-service'; // Required for Origami components.
-
-@import 'autocomplete/main';
-
-@include oAutocomplete();

--- a/src/components/Head.jsx
+++ b/src/components/Head.jsx
@@ -6,23 +6,7 @@ const Head = props => {
 		<head>
 			<title>{`${documentTitle} | Dramatis`}</title>
 
-			{/* Ordering of stylesheet groups is important. */}
-			<link rel="stylesheet" href="/stylesheets/normalize.css" />
-
-			<link rel="stylesheet" href="/stylesheets/color-variables.css" />
-
-			<link rel="stylesheet" href="/stylesheets/autocomplete.css" />
-			<link rel="stylesheet" href="/stylesheets/footer.css" />
-			<link rel="stylesheet" href="/stylesheets/header.css" />
-			<link rel="stylesheet" href="/stylesheets/instance.css" />
-			<link rel="stylesheet" href="/stylesheets/list.css" />
-			<link rel="stylesheet" href="/stylesheets/navigation.css" />
-			<link rel="stylesheet" href="/stylesheets/page.css" />
-			<link rel="stylesheet" href="/stylesheets/text.css" />
-
-			<link rel="stylesheet" href="/stylesheets/scss-imports.css" />
-
-			<link rel="stylesheet" href="/stylesheets/o-autocomplete-overrides.css" />
+			<link rel="stylesheet" href="/stylesheets/main.css" />
 
 			<script src="/scripts/main.js" />
 		</head>


### PR DESCRIPTION
This PR upgrades the autocomplete dependency to the current latest version ([v2.0.0](https://github.com/andygout/autocomplete/releases/tag/v2.0.0), which includes these changes: https://github.com/andygout/autocomplete/pull/4).

Consequently, it means that this repo no longer needs to handle SCSS whatsoever and can revise the way it prepares the client-side styles bundle.

### New dev dependencies:
- [postcss-import](https://www.npmjs.com/package/postcss-import)
- [rollup-plugin-postcss](https://www.npmjs.com/package/rollup-plugin-postcss)