### PR TITLE
Remove @financial-times/o-utils + use native debounce function

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "@financial-times/o-utils": "2.2.1",
     "autocomplete": "github:andygout/autocomplete#v2.0.0",
     "express": "5.1.0",
     "express-session": "1.18.2",

--- a/src/client/scripts/debounce.js
+++ b/src/client/scripts/debounce.js
@@ -1,0 +1,18 @@
+export default function debounce (func, wait) {
+
+	let timeout;
+
+	return function (...args) {
+
+		const later = () => {
+			timeout = null;
+			func.apply(this, args);
+		};
+
+		clearTimeout(timeout);
+
+		timeout = setTimeout(later, wait);
+
+	};
+
+}

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -1,5 +1,6 @@
 import Autocomplete from 'autocomplete';
-import { debounce } from '@financial-times/o-utils';
+
+import debounce from './debounce';
 
 import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants.js';
 


### PR DESCRIPTION
This PR removes the @financial-times/o-utils dependency in favour of a native `debounce` function.