### PR TITLE
Upgrade accessible-autocomplete 2.0.0 -> 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm": "11.6.0"
   },
   "dependencies": {
-    "accessible-autocomplete": "github:andygout/accessible-autocomplete#v2.0.0",
+    "accessible-autocomplete": "github:andygout/accessible-autocomplete#v2.0.1",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "morgan": "1.10.1",


### PR DESCRIPTION
This PR upgrades accessible-autocomplete to the current latest version: [2.0.1](https://github.com/andygout/accessible-autocomplete/releases/tag/v2.0.1), which includes the changes of this PR: https://github.com/andygout/accessible-autocomplete/pull/4.