### PR TITLE
Separate app.js + server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Server-side rendered (SSR) application that provides listings for theatrical productions, materials, and associated data.",
   "author": "https://github.com/andygout",
   "license": "MS-RSL",
-  "main": "src/app.js",
+  "main": "src/server.js",
   "scripts": {
     "format": "prettier \"**/*.{js,jsx,json,css,md,yml}\" --write",
     "lint": "eslint",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import postcss from 'rollup-plugin-postcss';
 
 const serverBundle = {
-	input: 'src/app.js',
+	input: 'src/server.js',
 	output: {
 		file: 'built/main.js',
 		sourcemap: 'inline'

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,5 @@
-import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle
-const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle
 
 import express from 'express';
 import session from 'express-session';
@@ -14,10 +10,13 @@ import { errorHandler } from './middleware/index.js';
 import apiRouter from './api-router.js';
 import router from './router.js';
 
+const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle
+const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle
+
 const app = express();
 
 app.use(
-	favicon(path.join(__dirname, 'assets', 'favicon.ico')), // Path is relative to `built/main.js`.
+	favicon(path.join(__dirname, 'assets', 'favicon.ico')),
 	logger('dev'),
 	session({ secret: 'secret', resave: false, saveUninitialized: true }),
 	express.static('public')
@@ -29,10 +28,4 @@ app.use(router);
 
 app.use(errorHandler);
 
-const port = '3003';
-
-app.set('port', port);
-
-const server = http.createServer(app);
-
-server.listen(port, () => console.log(`Listening on port ${port}`)); // eslint-disable-line no-console
+export default app;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,26 @@
+import http from 'node:http';
+
+import app from './app.js';
+
+const port = '3003';
+
+app.set('port', port);
+
+const server = http.createServer(app);
+
+server.listen(port, () => console.log(`Listening on port ${port}`)); // eslint-disable-line no-console
+
+const shutDown = async () => {
+	server.closeAllConnections();
+	await new Promise((resolve) => server.close(resolve));
+};
+
+process.on('SIGTERM', () => {
+	void shutDown();
+});
+
+process.on('SIGINT', () => {
+	void shutDown();
+});
+
+export default server;


### PR DESCRIPTION
This PR creates a separate `server.js` file to establish a clear separation of concerns:
- `app.js`: should only build and export the Express app, i.e. what the app is
- `server.js`: should start the HTTP server, i.e. how the app is run

Should this app use [supertest](https://www.npmjs.com/package/supertest) in the future then `app.js` is suitable to import in tests with `supertest(app)`. (dramatis-api started using supertest and depended on this setup as of this PR https://github.com/andygout/dramatis-api/pull/721)