### PR TITLE
Add eslint-plugin-import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,12 @@
 import js from '@eslint/js';
 import preactConfig from 'eslint-config-preact';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import importPlugin from 'eslint-plugin-import';
 import globals from 'globals';
 
 export default [
 	js.configs.recommended,
+	importPlugin.flatConfigs.recommended,
 	...preactConfig,
 	{
 		ignores: ['built/*', 'public/*']
@@ -14,10 +16,22 @@ export default [
 			globals: {
 				...globals.node
 			},
-			ecmaVersion: 2020,
+			ecmaVersion: 'latest',
 			sourceType: 'module'
 		},
 		rules: {
+			'import/namespace': ['error', { allowComputed: true }],
+			'import/order': [
+				'error',
+				{
+					groups: ['builtin', 'external', ['parent', 'sibling', 'index']],
+					'newlines-between': 'always',
+					alphabetize: {
+						order: 'asc',
+						caseInsensitive: true
+					}
+				}
+			],
 			'comma-dangle': 'error',
 			eqeqeq: 'error',
 			'guard-for-in': 'error',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "9.36.0",
     "eslint-config-preact": "2.0.0",
     "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-import": "2.32.0",
     "globals": "16.4.0",
     "lintspaces-cli": "1.0.0",
     "postcss-import": "16.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import commonjs from '@rollup/plugin-commonjs';
-import nodeResolve from '@rollup/plugin-node-resolve';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import postcssImport from 'postcss-import';
 import copy from 'rollup-plugin-copy';
 import esbuild from 'rollup-plugin-esbuild';

--- a/src/app.js
+++ b/src/app.js
@@ -6,8 +6,8 @@ import session from 'express-session';
 import logger from 'morgan';
 import favicon from 'serve-favicon';
 
-import { errorHandler } from './middleware/index.js';
 import apiRouter from './api-router.js';
+import { errorHandler } from './middleware/index.js';
 import router from './router.js';
 
 const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle

--- a/src/client/scripts/search-bar.js
+++ b/src/client/scripts/search-bar.js
@@ -1,5 +1,4 @@
 import Autocomplete from './autocomplete';
-
 import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants.js';
 
 const URL_BASE = 'http://localhost:3003';

--- a/src/components/CreativeProductionsList.jsx
+++ b/src/components/CreativeProductionsList.jsx
@@ -1,6 +1,6 @@
 import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
-import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 import ListWrapper from './ListWrapper.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const CreativeProductionsList = (props) => {
 	const { productions } = props;

--- a/src/components/CrewProductionsList.jsx
+++ b/src/components/CrewProductionsList.jsx
@@ -1,6 +1,6 @@
 import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
-import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 import ListWrapper from './ListWrapper.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const CrewProductionsList = (props) => {
 	const { productions } = props;

--- a/src/components/InstanceLink.jsx
+++ b/src/components/InstanceLink.jsx
@@ -1,7 +1,6 @@
 import { useContext } from 'preact/hooks';
 
 import { CurrentPath } from '../contexts/index.js';
-
 import { MODEL_TO_ROUTE_MAP } from '../utils/constants.js';
 
 const InstanceLink = (props) => {

--- a/src/components/ProducerCredits.jsx
+++ b/src/components/ProducerCredits.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'preact';
 
-import { capitalise } from '../lib/strings.js';
 import ProducerEntities from './ProducerEntities.jsx';
+import { capitalise } from '../lib/strings.js';
 
 const ProducerCredits = (props) => {
 	const { credits } = props;

--- a/src/components/ProducerProductionsList.jsx
+++ b/src/components/ProducerProductionsList.jsx
@@ -1,8 +1,8 @@
 import { Fragment } from 'preact';
 
+import ListWrapper from './ListWrapper.jsx';
 import ProducerCredits from './ProducerCredits.jsx';
 import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
-import ListWrapper from './ListWrapper.jsx';
 
 const ProducerProductionsList = (props) => {
 	const { productions } = props;

--- a/src/components/WritingCredits.jsx
+++ b/src/components/WritingCredits.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'preact';
 
-import { capitalise } from '../lib/strings.js';
 import WritingEntities from './WritingEntities.jsx';
+import { capitalise } from '../lib/strings.js';
 
 const WritingCredits = (props) => {
 	const { credits, isAppendage } = props;

--- a/src/controllers/helpers/render-component-to-string.jsx
+++ b/src/controllers/helpers/render-component-to-string.jsx
@@ -1,4 +1,4 @@
-import render from 'preact-render-to-string';
+import { render } from 'preact-render-to-string';
 
 const renderComponentToString = (PageComponent, props) => {
 	return render(<PageComponent {...props} />);

--- a/src/pages/lists/index.js
+++ b/src/pages/lists/index.js
@@ -1,5 +1,5 @@
-import Awards from './Awards.jsx';
 import AwardCeremonies from './AwardCeremonies.jsx';
+import Awards from './Awards.jsx';
 import Characters from './Characters.jsx';
 import Companies from './Companies.jsx';
 import Festivals from './Festivals.jsx';


### PR DESCRIPTION
This PR adds the [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) package:

> This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, and prevent issues with misspelling of file paths and import names. All the goodness that the ES2015+ static module syntax intends to provide, marked up in your editor.

The main intent is to ensure logical grouping of imports:
- Node.js native imports
- Imports from external packages
- Imports from files native to the repository

By default it applies alphabetical ordering within those groups based on the filepath. This means that where previously imports (in the group of the files native to the repository) were ordered by their absolute position within the file structure, they are now ordered by the file path, meaning that files in nested directories will prioritise other files in the same directory before gradually working outwards. Ultimately, for the benefit of automating these decisions versus the cognitive and maintenance work to maintain a slightly different personal preference, the trade-off seems worth it.

Example from https://github.com/andygout/dramatis-api/pull/722: `src/models/CharacterDepiction.js` has imports from `src/lib/strings.js` and `src/models/Character.js`.

#### `src/models/CharacterDepiction.js` — before:

```js
import { getTrimmedOrEmptyString } from '../lib/strings.js';
import Character from './Character.js';
```

#### `src/models/CharacterDepiction.js` — before:

```js
import Character from './Character.js';
import { getTrimmedOrEmptyString } from '../lib/strings.js';
```

### New dev dependencies:
- [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
