### PR TITLE
Apply Prettier format check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
           name: Install
           command: npm install
       - run:
+          name: Format checks
+          command: npm run format-check
+      - run:
           name: Lint checks
           command: npm run lint-check
       - run:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "src/server.js",
   "scripts": {
     "format": "prettier \"**/*.{js,jsx,json,css,md,yml}\" --write",
+    "format-check": "prettier \"**/*.{js,jsx,json,css,md,yml}\" --check",
     "lint": "eslint",
     "lintspaces": "git ls-files ':!:*.ico' | xargs lintspaces -e .editorconfig",
     "lint-check": "npm run lint && npm run lintspaces",


### PR DESCRIPTION
This PR adds a Prettier format check as a step in the CI workflow.

This is so that if any commits are made using the `--no-verify` flag (which will sidestep the pre-commit hook that formats staged files) and files are not formatted in adherence with the Prettier configuration then they will be caught and need correctly formatting before they can be merged to the `main` branch.