### PR TITLE
Add lint-fix command to apply ESLint fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier \"**/*.{js,jsx,json,css,md,yml}\" --write",
     "format-check": "prettier \"**/*.{js,jsx,json,css,md,yml}\" --check",
     "lint": "eslint",
+    "lint-fix": "eslint --fix",
     "lintspaces": "git ls-files ':!:*.ico' | xargs lintspaces -e .editorconfig",
     "lint-check": "npm run lint && npm run lintspaces",
     "lint-staged": "lint-staged",


### PR DESCRIPTION
This PR adds a `lint-fix` command that will apply ESLint fixes where it is able.

This is so that if the `eslint` checks ever encounter an error, then the command can quickly be run to see what a fix would look like.

The reason I am not applying the fix automatically before the checks is because it is useful to see what the errors are to understand them and what the correct fix is rather than likely being oblivious because it was fixed without me even being aware of it.